### PR TITLE
Helper: make maxValuesPerFacet configurable

### DIFF
--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -331,7 +331,7 @@
      * @return {hash}
      */
     _getDisjunctiveFacetSearchParams: function(facet) {
-      return extend({}, this.searchParams, {
+      var params = extend({}, this.searchParams, {
         hitsPerPage: 1,
         page: 0,
         attributesToRetrieve: [],
@@ -340,6 +340,12 @@
         facets: facet,
         facetFilters: this._getFacetFilters(facet)
       });
+
+      if (typeof (this.options.maxValuesPerFacet) !== 'undefined') {
+        params.maxValuesPerFacet = this.options.maxValuesPerFacet;
+      }
+
+      return params;
     },
 
     /**


### PR DESCRIPTION
- If any value is sent through in this field it will override the value
  set in the backend
- Setting null or an empty array as the value for this option will cause
  it to return all the filters