### PR TITLE
new AlgoliaSearch() => algoliasearch()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,12 +2,24 @@ CHANGELOG
 
 UNRELEASED
     * some linting fixes
-    * removed AlgoliaExplainResults
     * test suite, including request strategy test suite
     * IE10 should now behave as a CORS supported XMLHttpRequest browser, as it is
     * running tests on many browsers, using saucelabs
     * refactor around `_makeXmlHttpRequestByHost` and `_makeJsonpRequestByHost`
     * remove unused opts.callback(retry, success, obj, message) in all make..Request functions
+    * BREAKING CHANGE, changed initialization from `new AlgoliaSearch()` => `algoliasearch()` #40
+      - The only exported global property is now `algoliasearch`
+      - `opts`:
+        - `dsnHost` removed, use `hosts:[dsnHost, other hosts]`
+        - `dsn` removed, use `hosts:[non-dsn-host, non-dsn-host]`
+        - `requestTimeoutInMs` renamed to `timeout`
+        - `method` renamed to `protocol`. Protocol should be specified as `http:` or `https:`
+        - `hosts` behavior changed, when using custom hosts:
+          - no shuffling
+          - no dsn host is prepended to the list
+      - removed `AlgoliaExplainResults`, no obvious use ATM
+      - calling algoliasearch() without an applicationID or apiKey will throw
+      - Helper: `new AlgoliaSearchHelper()` => `algoliasearch.helper()`, same function signature
 
 2015-02-03  2.9.2
     * Fixed calls to `.search(function() {})`, `.search(null, function() {})`, `.search(undefined, function() {})

--- a/examples/autocomplete.html
+++ b/examples/autocomplete.html
@@ -36,7 +36,7 @@
     <script type="text/javascript">
       $(document).ready(function() {
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
         var index = algolia.initIndex('contacts');
 

--- a/examples/instantsearch+faceting.html
+++ b/examples/instantsearch+faceting.html
@@ -36,7 +36,7 @@
         var refinements = {};
         var $inputfield = $("#q");
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
         var index = algolia.initIndex('bestbuy');
 

--- a/examples/instantsearch+helper+excludes.html
+++ b/examples/instantsearch+helper+excludes.html
@@ -39,9 +39,9 @@
       $(document).ready(function() {
         var $inputfield = $("#q");
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
-        var helper = new AlgoliaSearchHelper(algolia, 'bestbuy', {
+        var helper = algoliasearch.helper(algolia, 'bestbuy', {
           // conjunctive facets (link)
           facets: ['type', 'shipping'],
           // disjunctive facets (checkbox)

--- a/examples/instantsearch+helper.html
+++ b/examples/instantsearch+helper.html
@@ -39,9 +39,9 @@
       $(document).ready(function() {
         var $inputfield = $("#q");
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
-        var helper = new AlgoliaSearchHelper(algolia, 'bestbuy', {
+        var helper = algoliasearch.helper(algolia, 'bestbuy', {
           // conjunctive facets (link)
           facets: ['type', 'shipping'],
           // disjunctive facets (checkbox)

--- a/examples/instantsearch+pagination.html
+++ b/examples/instantsearch+pagination.html
@@ -33,7 +33,7 @@
         var $inputfield = $("#q");
 
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
         var index = algolia.initIndex('contacts');
 

--- a/examples/instantsearch.html
+++ b/examples/instantsearch.html
@@ -64,7 +64,7 @@
         var $inputfield = $('#q');
 
         // Replace the following values by your ApplicationID and ApiKey.
-        var algolia = new AlgoliaSearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+        var algolia = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
         // Replace the following value by the name of the index you want to query.
         var index = algolia.initIndex('contacts');
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+module.exports = algoliasearch;
+
+function algoliasearch(applicationID, apiKey, opts) {
+  var AlgoliaSearch = require('./src/algoliasearch');
+
+  return new AlgoliaSearch(applicationID, apiKey, opts);
+}

--- a/package.json
+++ b/package.json
@@ -27,14 +27,13 @@
   ],
   "devDependencies": {
     "browserify": "9.0.3",
-    "browserify-shim": "3.8.3",
     "bulk-require": "0.2.1",
     "bulkify": "1.1.1",
     "chance": "0.7.3",
     "domready": "0.3.0",
     "eslint": "0.15.0",
     "express": "4.12.1",
-    "faux-jax": "2.0.0",
+    "faux-jax": "3.0.1",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-concat": "0.5.1",
@@ -42,38 +41,29 @@
     "grunt-contrib-uglify": "0.8.0",
     "grunt-sed": "0.1.1",
     "http-server": "0.7.5",
-    "lodash": "3.3.1",
-    "lodash-compat": "3.3.1",
     "morgan": "1.5.1",
     "phantomjs": "1.9.15",
     "sinon": "1.12.2",
     "tap-growl": "1.0.5",
     "tap-spec": "2.2.1",
     "tape": "3.5.0",
+    "uglify-js": "2.4.16",
     "url-parse": "1.0.0",
-    "writable-window-method": "1.0.0",
+    "writable-window-method": "1.0.3",
     "xhr": "2.0.1",
-    "zuul": "2.1.0",
-    "zuul-ngrok": "git://github.com/rase-/zuul-ngrok#c259c46ec4c111e71a671b00240fda2eb65df4ff"
-  },
-  "browser": {
-    "algoliasearch": "./dist/algoliasearch.js"
-  },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
-  "browserify-shim": {
-    "algoliasearch": "AlgoliaSearch"
+    "zuul": "2.1.1",
+    "zuul-ngrok": "3.0.0"
   },
   "scripts": {
-    "test": "grunt build && zuul --phantom --ui tape test/run.js | tap-growl | tap-spec && npm run lint",
-    "test-ci": "grunt build && DEBUG=zuul* zuul --tunnel ngrok test/run.js && npm run lint",
-    "dev": "grunt build && DEBUG=zuul* zuul --local 8080 --ui tape test/run.js",
+    "test": "zuul --phantom --ui tape test/run.js | tap-growl | tap-spec && npm run lint",
+    "test-ci": "DEBUG=zuul* zuul --tunnel ngrok test/run.js && npm run lint",
+    "dev": "DEBUG=zuul* zuul --local 8080 --ui tape test/run.js",
     "examples": "http-server . -a 127.0.0.1",
     "lint": "eslint --quiet test/"
   },
   "version": "2.9.2",
-  "dependencies": {}
+  "dependencies": {
+    "lodash-compat": "3.5.0"
+  },
+  "main": "index.js"
 }

--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -1,5 +1,6 @@
-/* global angular */
-angular.module('algoliasearch', [])
+var algoliasearch = require('../');
+
+global.angular.module('algoliasearch', [])
   .service('algolia', ['$injector', function ($injector) {
     return {
       Client: function(applicationID, apiKey, options) {
@@ -7,7 +8,7 @@ angular.module('algoliasearch', [])
         options.angular = {
           '$injector': $injector
         };
-        return new AlgoliaSearch(applicationID, apiKey, options);
+        return algoliasearch(applicationID, apiKey, options);
       }
     };
   }]);

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -1,479 +1,483 @@
-(function($) {
-  var extend = function(out) {
-    out = out || {};
-    for (var i = 1; i < arguments.length; i++) {
-      if (!arguments[i]) {
-        continue;
-      }
-      for (var key in arguments[i]) {
-        if (arguments[i].hasOwnProperty(key)) {
-          out[key] = arguments[i][key];
-        }
+module.exports = helper;
+
+/**
+ * Algolia Search Helper providing faceting and disjunctive faceting
+ * @param {AlgoliaSearch} client - An AlgoliaSearch client
+ * @param {string} index - The index name to query
+ * @param {Object} [opts] an associative array defining the hitsPerPage, list of facets, the list of disjunctive facets and the default facet filters
+ */
+function helper(client, index, opts) {
+  return new AlgoliaSearchHelper(client, index, opts);
+}
+
+var extend = function(out) {
+  out = out || {};
+  for (var i = 1; i < arguments.length; i++) {
+    if (!arguments[i]) {
+      continue;
+    }
+    for (var key in arguments[i]) {
+      if (arguments[i].hasOwnProperty(key)) {
+        out[key] = arguments[i][key];
       }
     }
-    return out;
+  }
+  return out;
+};
+
+function AlgoliaSearchHelper(client, index, options) {
+  /// Default options
+  var defaults = {
+    facets: [],            // list of facets to compute
+    disjunctiveFacets: [], // list of disjunctive facets to compute
+    hitsPerPage: 20,       // number of hits per page
+    defaultFacetFilters: [] // the default list of facetFilters
   };
+
+  this.init(client, index, extend({}, defaults, options));
+}
+
+AlgoliaSearchHelper.prototype = {
+  /**
+   * Initialize a new AlgoliaSearchHelper
+   * @param  {AlgoliaSearch} client an AlgoliaSearch client
+   * @param  {string} index the index name to query
+   * @param  {hash} options an associative array defining the hitsPerPage, list of facets and list of disjunctive facets
+   * @return {AlgoliaSearchHelper}
+   */
+  init: function(client, index, options) {
+    this.client = client;
+    this.index = index;
+    this.options = options;
+    this.page = 0;
+    this.refinements = {};
+    this.excludes = {};
+    this.disjunctiveRefinements = {};
+    this.extraQueries = [];
+  },
 
   /**
-   * Algolia Search Helper providing faceting and disjunctive faceting
-   * @param {AlgoliaSearch} client an AlgoliaSearch client
-   * @param {string} index the index name to query
-   * @param {hash} options an associative array defining the hitsPerPage, list of facets, the list of disjunctive facets and the default facet filters
+   * Perform a query
+   * @param  {string} q the user query
+   * @param  {function} searchCallback the result callback called with two arguments:
+   *  success: boolean set to true if the request was successfull
+   *  content: the query answer with an extra 'disjunctiveFacets' attribute
    */
-  window.AlgoliaSearchHelper = function(client, index, options) {
-    /// Default options
-    var defaults = {
-      facets: [],            // list of facets to compute
-      disjunctiveFacets: [], // list of disjunctive facets to compute
-      hitsPerPage: 20,       // number of hits per page
-      defaultFacetFilters: [] // the default list of facetFilters
-    };
+  search: function(q, searchCallback, searchParams) {
+    this.q = q;
+    this.searchCallback = searchCallback;
+    this.searchParams = searchParams || {};
+    this.page = this.page || 0;
+    this.refinements = this.refinements || {};
+    this.disjunctiveRefinements = this.disjunctiveRefinements || {};
+    this._search();
+  },
 
-    this.init(client, index, extend({}, defaults, options));
-  };
+  /**
+   * Remove all refinements (disjunctive + conjunctive)
+   */
+  clearRefinements: function() {
+    this.disjunctiveRefinements = {};
+    this.refinements = {};
+  },
 
-  window.AlgoliaSearchHelper.prototype = {
-    /**
-     * Initialize a new AlgoliaSearchHelper
-     * @param  {AlgoliaSearch} client an AlgoliaSearch client
-     * @param  {string} index the index name to query
-     * @param  {hash} options an associative array defining the hitsPerPage, list of facets and list of disjunctive facets
-     * @return {AlgoliaSearchHelper}
-     */
-    init: function(client, index, options) {
-      this.client = client;
-      this.index = index;
-      this.options = options;
-      this.page = 0;
-      this.refinements = {};
-      this.excludes = {};
-      this.disjunctiveRefinements = {};
-      this.extraQueries = [];
-    },
+  /**
+   * Ensure a facet refinement exists
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  addDisjunctiveRefine: function(facet, value) {
+    this.disjunctiveRefinements = this.disjunctiveRefinements || {};
+    this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
+    this.disjunctiveRefinements[facet][value] = true;
+  },
 
-    /**
-     * Perform a query
-     * @param  {string} q the user query
-     * @param  {function} searchCallback the result callback called with two arguments:
-     *  success: boolean set to true if the request was successfull
-     *  content: the query answer with an extra 'disjunctiveFacets' attribute
-     */
-    search: function(q, searchCallback, searchParams) {
-      this.q = q;
-      this.searchCallback = searchCallback;
-      this.searchParams = searchParams || {};
-      this.page = this.page || 0;
-      this.refinements = this.refinements || {};
-      this.disjunctiveRefinements = this.disjunctiveRefinements || {};
-      this._search();
-    },
+  /**
+   * Ensure a facet refinement does not exist
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  removeDisjunctiveRefine: function(facet, value) {
+    this.disjunctiveRefinements = this.disjunctiveRefinements || {};
+    this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
+    try {
+      delete this.disjunctiveRefinements[facet][value];
+    } catch (e) {
+      this.disjunctiveRefinements[facet][value] = undefined; // IE compat
+    }
+  },
 
-    /**
-     * Remove all refinements (disjunctive + conjunctive)
-     */
-    clearRefinements: function() {
-      this.disjunctiveRefinements = {};
-      this.refinements = {};
-    },
+  /**
+   * Ensure a facet refinement exists
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  addRefine: function(facet, value) {
+    var refinement = facet + ':' + value;
+    this.refinements = this.refinements || {};
+    this.refinements[refinement] = true;
+  },
 
-    /**
-     * Ensure a facet refinement exists
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    addDisjunctiveRefine: function(facet, value) {
-      this.disjunctiveRefinements = this.disjunctiveRefinements || {};
-      this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
-      this.disjunctiveRefinements[facet][value] = true;
-    },
+  /**
+   * Ensure a facet refinement does not exist
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  removeRefine: function(facet, value) {
+    var refinement = facet + ':' + value;
+    this.refinements = this.refinements || {};
+    this.refinements[refinement] = false;
+  },
 
-    /**
-     * Ensure a facet refinement does not exist
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    removeDisjunctiveRefine: function(facet, value) {
-      this.disjunctiveRefinements = this.disjunctiveRefinements || {};
-      this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
-      try {
-        delete this.disjunctiveRefinements[facet][value];
-      } catch (e) {
-        this.disjunctiveRefinements[facet][value] = undefined; // IE compat
-      }
-    },
+  /**
+   * Ensure a facet exclude exists
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  addExclude: function(facet, value) {
+    var refinement = facet + ':-' + value;
+    this.excludes = this.excludes || {};
+    this.excludes[refinement] = true;
+  },
 
-    /**
-     * Ensure a facet refinement exists
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    addRefine: function(facet, value) {
-      var refinement = facet + ':' + value;
-      this.refinements = this.refinements || {};
-      this.refinements[refinement] = true;
-    },
+  /**
+   * Ensure a facet exclude does not exist
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   */
+  removeExclude: function(facet, value) {
+    var refinement = facet + ':-' + value;
+    this.excludes = this.excludes || {};
+    this.excludes[refinement] = false;
+  },
 
-    /**
-     * Ensure a facet refinement does not exist
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    removeRefine: function(facet, value) {
-      var refinement = facet + ':' + value;
-      this.refinements = this.refinements || {};
-      this.refinements[refinement] = false;
-    },
-
-    /**
-     * Ensure a facet exclude exists
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    addExclude: function(facet, value) {
-      var refinement = facet + ':-' + value;
-      this.excludes = this.excludes || {};
-      this.excludes[refinement] = true;
-    },
-
-    /**
-     * Ensure a facet exclude does not exist
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     */
-    removeExclude: function(facet, value) {
-      var refinement = facet + ':-' + value;
-      this.excludes = this.excludes || {};
-      this.excludes[refinement] = false;
-    },
-
-    /**
-     * Toggle refinement state of an exclude
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     * @return {boolean} true if the facet has been found
-     */
-    toggleExclude: function(facet, value) {
-      for (var i = 0; i < this.options.facets.length; ++i) {
-        if (this.options.facets[i] === facet) {
-          var refinement = facet + ':-' + value;
-          this.excludes[refinement] = !this.excludes[refinement];
-          this.page = 0;
-          this._search();
-          return true;
-        }
-      }
-      return false;
-    },
-
-    /**
-     * Toggle refinement state of a facet
-     * @param  {string} facet the facet to refine
-     * @param  {string} value the associated value
-     * @return {boolean} true if the facet has been found
-     */
-    toggleRefine: function(facet, value) {
-      for (var i = 0; i < this.options.facets.length; ++i) {
-        if (this.options.facets[i] === facet) {
-          var refinement = facet + ':' + value;
-          this.refinements[refinement] = !this.refinements[refinement];
-          this.page = 0;
-          this._search();
-          return true;
-        }
-      }
-      this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
-      for (var j = 0; j < this.options.disjunctiveFacets.length; ++j) {
-        if (this.options.disjunctiveFacets[j] === facet) {
-          this.disjunctiveRefinements[facet][value] = !this.disjunctiveRefinements[facet][value];
-          this.page = 0;
-          this._search();
-          return true;
-        }
-      }
-      return false;
-    },
-
-    /**
-     * Check the refinement state of a facet
-     * @param  {string}  facet the facet
-     * @param  {string}  value the associated value
-     * @return {boolean} true if refined
-     */
-    isRefined: function(facet, value) {
-      var refinement = facet + ':' + value;
-      if (this.refinements[refinement]) {
+  /**
+   * Toggle refinement state of an exclude
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   * @return {boolean} true if the facet has been found
+   */
+  toggleExclude: function(facet, value) {
+    for (var i = 0; i < this.options.facets.length; ++i) {
+      if (this.options.facets[i] === facet) {
+        var refinement = facet + ':-' + value;
+        this.excludes[refinement] = !this.excludes[refinement];
+        this.page = 0;
+        this._search();
         return true;
       }
-      if (this.disjunctiveRefinements[facet] && this.disjunctiveRefinements[facet][value]) {
+    }
+    return false;
+  },
+
+  /**
+   * Toggle refinement state of a facet
+   * @param  {string} facet the facet to refine
+   * @param  {string} value the associated value
+   * @return {boolean} true if the facet has been found
+   */
+  toggleRefine: function(facet, value) {
+    for (var i = 0; i < this.options.facets.length; ++i) {
+      if (this.options.facets[i] === facet) {
+        var refinement = facet + ':' + value;
+        this.refinements[refinement] = !this.refinements[refinement];
+        this.page = 0;
+        this._search();
         return true;
       }
-      return false;
-    },
-
-    /**
-     * Check the exclude state of a facet
-     * @param  {string}  facet the facet
-     * @param  {string}  value the associated value
-     * @return {boolean} true if refined
-     */
-    isExcluded: function(facet, value) {
-      var refinement = facet + ':-' + value;
-      if (this.excludes[refinement]) {
+    }
+    this.disjunctiveRefinements[facet] = this.disjunctiveRefinements[facet] || {};
+    for (var j = 0; j < this.options.disjunctiveFacets.length; ++j) {
+      if (this.options.disjunctiveFacets[j] === facet) {
+        this.disjunctiveRefinements[facet][value] = !this.disjunctiveRefinements[facet][value];
+        this.page = 0;
+        this._search();
         return true;
       }
-      return false;
-    },
+    }
+    return false;
+  },
 
-    /**
-     * Go to next page
-     */
-    nextPage: function() {
-      this._gotoPage(this.page + 1);
-    },
+  /**
+   * Check the refinement state of a facet
+   * @param  {string}  facet the facet
+   * @param  {string}  value the associated value
+   * @return {boolean} true if refined
+   */
+  isRefined: function(facet, value) {
+    var refinement = facet + ':' + value;
+    if (this.refinements[refinement]) {
+      return true;
+    }
+    if (this.disjunctiveRefinements[facet] && this.disjunctiveRefinements[facet][value]) {
+      return true;
+    }
+    return false;
+  },
 
-    /**
-     * Go to previous page
-     */
-    previousPage: function() {
-      if (this.page > 0) {
-        this._gotoPage(this.page - 1);
+  /**
+   * Check the exclude state of a facet
+   * @param  {string}  facet the facet
+   * @param  {string}  value the associated value
+   * @return {boolean} true if refined
+   */
+  isExcluded: function(facet, value) {
+    var refinement = facet + ':-' + value;
+    if (this.excludes[refinement]) {
+      return true;
+    }
+    return false;
+  },
+
+  /**
+   * Go to next page
+   */
+  nextPage: function() {
+    this._gotoPage(this.page + 1);
+  },
+
+  /**
+   * Go to previous page
+   */
+  previousPage: function() {
+    if (this.page > 0) {
+      this._gotoPage(this.page - 1);
+    }
+  },
+
+  /**
+   * Goto a page
+   * @param  {integer} page The page number
+   */
+  gotoPage: function(page) {
+      this._gotoPage(page);
+  },
+
+  /**
+   * Configure the page but do not trigger a reload
+   * @param  {integer} page The page number
+   */
+  setPage: function(page) {
+    this.page = page;
+  },
+
+  /**
+   * Configure the underlying index name
+   * @param {string} name the index name
+   */
+  setIndex: function(name) {
+    this.index = name;
+  },
+
+  /**
+   * Get the underlying configured index name
+   */
+  getIndex: function() {
+    return this.index;
+  },
+
+  /**
+   * Clear the extra queries added to the underlying batch of queries
+   */
+  clearExtraQueries: function() {
+    this.extraQueries = [];
+  },
+
+  /**
+   * Add an extra query to the underlying batch of queries. Once you add queries
+   * to the batch, the 2nd parameter of the searchCallback will be an object with a `results`
+   * attribute listing all search results.
+   */
+  addExtraQuery: function(index, query, params) {
+    this.extraQueries.push({ index: index, query: query, params: (params || {}) });
+  },
+
+  ///////////// PRIVATE
+
+  /**
+   * Goto a page
+   * @param  {integer} page The page number
+   */
+  _gotoPage: function(page) {
+    this.page = page;
+    this._search();
+  },
+
+  /**
+   * Perform the underlying queries
+   */
+  _search: function() {
+    this.client.startQueriesBatch();
+    this.client.addQueryInBatch(this.index, this.q, this._getHitsSearchParams());
+    var disjunctiveFacets = [];
+    var unusedDisjunctiveFacets = {};
+    var i = 0;
+    for (i = 0; i < this.options.disjunctiveFacets.length; ++i) {
+      var facet = this.options.disjunctiveFacets[i];
+      if (this._hasDisjunctiveRefinements(facet)) {
+        disjunctiveFacets.push(facet);
+      } else {
+        unusedDisjunctiveFacets[facet] = true;
       }
-    },
-
-    /**
-     * Goto a page
-     * @param  {integer} page The page number
-     */
-    gotoPage: function(page) {
-        this._gotoPage(page);
-    },
-
-    /**
-     * Configure the page but do not trigger a reload
-     * @param  {integer} page The page number
-     */
-    setPage: function(page) {
-      this.page = page;
-    },
-
-    /**
-     * Configure the underlying index name
-     * @param {string} name the index name
-     */
-    setIndex: function(name) {
-      this.index = name;
-    },
-
-    /**
-     * Get the underlying configured index name
-     */
-    getIndex: function() {
-      return this.index;
-    },
-
-    /**
-     * Clear the extra queries added to the underlying batch of queries
-     */
-    clearExtraQueries: function() {
-      this.extraQueries = [];
-    },
-
-    /**
-     * Add an extra query to the underlying batch of queries. Once you add queries
-     * to the batch, the 2nd parameter of the searchCallback will be an object with a `results`
-     * attribute listing all search results.
-     */
-    addExtraQuery: function(index, query, params) {
-      this.extraQueries.push({ index: index, query: query, params: (params || {}) });
-    },
-
-    ///////////// PRIVATE
-
-    /**
-     * Goto a page
-     * @param  {integer} page The page number
-     */
-    _gotoPage: function(page) {
-      this.page = page;
-      this._search();
-    },
-
-    /**
-     * Perform the underlying queries
-     */
-    _search: function() {
-      this.client.startQueriesBatch();
-      this.client.addQueryInBatch(this.index, this.q, this._getHitsSearchParams());
-      var disjunctiveFacets = [];
-      var unusedDisjunctiveFacets = {};
-      var i = 0;
-      for (i = 0; i < this.options.disjunctiveFacets.length; ++i) {
-        var facet = this.options.disjunctiveFacets[i];
-        if (this._hasDisjunctiveRefinements(facet)) {
-          disjunctiveFacets.push(facet);
-        } else {
-          unusedDisjunctiveFacets[facet] = true;
-        }
+    }
+    for (i = 0; i < disjunctiveFacets.length; ++i) {
+      this.client.addQueryInBatch(this.index, this.q, this._getDisjunctiveFacetSearchParams(disjunctiveFacets[i]));
+    }
+    for (i = 0; i < this.extraQueries.length; ++i) {
+      this.client.addQueryInBatch(this.extraQueries[i].index, this.extraQueries[i].query, this.extraQueries[i].params);
+    }
+    var self = this;
+    this.client.sendQueriesBatch(function(success, content) {
+      if (!success) {
+        self.searchCallback(false, content);
+        return;
       }
-      for (i = 0; i < disjunctiveFacets.length; ++i) {
-        this.client.addQueryInBatch(this.index, this.q, this._getDisjunctiveFacetSearchParams(disjunctiveFacets[i]));
-      }
-      for (i = 0; i < this.extraQueries.length; ++i) {
-        this.client.addQueryInBatch(this.extraQueries[i].index, this.extraQueries[i].query, this.extraQueries[i].params);
-      }
-      var self = this;
-      this.client.sendQueriesBatch(function(success, content) {
-        if (!success) {
-          self.searchCallback(false, content);
-          return;
-        }
-        var aggregatedAnswer = content.results[0];
-        aggregatedAnswer.disjunctiveFacets = aggregatedAnswer.disjunctiveFacets || {};
-        aggregatedAnswer.facetStats = aggregatedAnswer.facetStats || {};
-        // create disjunctive facets from facets (disjunctive facets without refinements)
-        for (var facet in unusedDisjunctiveFacets) {
-          if (aggregatedAnswer.facets[facet] && !aggregatedAnswer.disjunctiveFacets[facet]) {
-            aggregatedAnswer.disjunctiveFacets[facet] = aggregatedAnswer.facets[facet];
-            try {
-              delete aggregatedAnswer.facets[facet];
-            } catch (e) {
-              aggregatedAnswer.facets[facet] = undefined; // IE compat
-            }
+      var aggregatedAnswer = content.results[0];
+      aggregatedAnswer.disjunctiveFacets = aggregatedAnswer.disjunctiveFacets || {};
+      aggregatedAnswer.facetStats = aggregatedAnswer.facetStats || {};
+      // create disjunctive facets from facets (disjunctive facets without refinements)
+      for (var facet in unusedDisjunctiveFacets) {
+        if (aggregatedAnswer.facets[facet] && !aggregatedAnswer.disjunctiveFacets[facet]) {
+          aggregatedAnswer.disjunctiveFacets[facet] = aggregatedAnswer.facets[facet];
+          try {
+            delete aggregatedAnswer.facets[facet];
+          } catch (e) {
+            aggregatedAnswer.facets[facet] = undefined; // IE compat
           }
         }
-        // aggregate the disjunctive facets
-        for (i = 0; i < disjunctiveFacets.length; ++i) {
-          for (var dfacet in content.results[i + 1].facets) {
-            aggregatedAnswer.disjunctiveFacets[dfacet] = content.results[i + 1].facets[dfacet];
-            if (self.disjunctiveRefinements[dfacet]) {
-              for (var value in self.disjunctiveRefinements[dfacet]) {
-                // add the disjunctive reginements if it is no more retrieved
-                if (!aggregatedAnswer.disjunctiveFacets[dfacet][value] && self.disjunctiveRefinements[dfacet][value]) {
-                  aggregatedAnswer.disjunctiveFacets[dfacet][value] = 0;
-                }
+      }
+      // aggregate the disjunctive facets
+      for (i = 0; i < disjunctiveFacets.length; ++i) {
+        for (var dfacet in content.results[i + 1].facets) {
+          aggregatedAnswer.disjunctiveFacets[dfacet] = content.results[i + 1].facets[dfacet];
+          if (self.disjunctiveRefinements[dfacet]) {
+            for (var value in self.disjunctiveRefinements[dfacet]) {
+              // add the disjunctive reginements if it is no more retrieved
+              if (!aggregatedAnswer.disjunctiveFacets[dfacet][value] && self.disjunctiveRefinements[dfacet][value]) {
+                aggregatedAnswer.disjunctiveFacets[dfacet][value] = 0;
               }
             }
           }
-          // aggregate the disjunctive facets stats
-          for (var stats in content.results[i + 1].facets_stats) {
-            aggregatedAnswer.facetStats[stats] = content.results[i + 1].facets_stats[stats];
+        }
+        // aggregate the disjunctive facets stats
+        for (var stats in content.results[i + 1].facets_stats) {
+          aggregatedAnswer.facetStats[stats] = content.results[i + 1].facets_stats[stats];
+        }
+      }
+      // add the excludes
+      for (var exclude in self.excludes) {
+        if (self.excludes[exclude]) {
+          var e = exclude.indexOf(':-');
+          var facet = exclude.slice(0, e);
+          var value = exclude.slice(e + 2);
+          aggregatedAnswer.facets[facet] = aggregatedAnswer.facets[facet] || {};
+          if (!aggregatedAnswer.facets[facet][value]) {
+            aggregatedAnswer.facets[facet][value] = 0;
           }
         }
-        // add the excludes
-        for (var exclude in self.excludes) {
-          if (self.excludes[exclude]) {
-            var e = exclude.indexOf(':-');
-            var facet = exclude.slice(0, e);
-            var value = exclude.slice(e + 2);
-            aggregatedAnswer.facets[facet] = aggregatedAnswer.facets[facet] || {};
-            if (!aggregatedAnswer.facets[facet][value]) {
-              aggregatedAnswer.facets[facet][value] = 0;
-            }
-          }
+      }
+      // call the actual callback
+      if (self.extraQueries.length === 0) {
+        self.searchCallback(true, aggregatedAnswer);
+      } else {
+        // append the extra queries
+        var c = { results: [ aggregatedAnswer ] };
+        for (i = 0; i < self.extraQueries.length; ++i) {
+          c.results.push(content.results[1 + disjunctiveFacets.length + i]);
         }
-        // call the actual callback
-        if (self.extraQueries.length === 0) {
-          self.searchCallback(true, aggregatedAnswer);
-        } else {
-          // append the extra queries
-          var c = { results: [ aggregatedAnswer ] };
-          for (i = 0; i < self.extraQueries.length; ++i) {
-            c.results.push(content.results[1 + disjunctiveFacets.length + i]);
-          }
-          self.searchCallback(true, c);
-        }
-      });
-    },
+        self.searchCallback(true, c);
+      }
+    });
+  },
 
-    /**
-     * Build search parameters used to fetch hits
-     * @return {hash}
-     */
-    _getHitsSearchParams: function() {
-      var facets = [];
-      var i = 0;
-      for (i = 0; i < this.options.facets.length; ++i) {
-        facets.push(this.options.facets[i]);
-      }
-      for (i = 0; i < this.options.disjunctiveFacets.length; ++i) {
-        var facet = this.options.disjunctiveFacets[i];
-        if (!this._hasDisjunctiveRefinements(facet)) {
-          facets.push(facet);
-        }
-      }
-      return extend({}, {
-        hitsPerPage: this.options.hitsPerPage,
-        page: this.page,
-        facets: facets,
-        facetFilters: this._getFacetFilters()
-      }, this.searchParams);
-    },
-
-    /**
-     * Build search parameters used to fetch a disjunctive facet
-     * @param  {string} facet the associated facet name
-     * @return {hash}
-     */
-    _getDisjunctiveFacetSearchParams: function(facet) {
-      return extend({}, this.searchParams, {
-        hitsPerPage: 1,
-        page: 0,
-        attributesToRetrieve: [],
-        attributesToHighlight: [],
-        attributesToSnippet: [],
-        facets: facet,
-        facetFilters: this._getFacetFilters(facet)
-      });
-    },
-
-    /**
-     * Test if there are some disjunctive refinements on the facet
-     */
-    _hasDisjunctiveRefinements: function(facet) {
-      for (var value in this.disjunctiveRefinements[facet]) {
-        if (this.disjunctiveRefinements[facet][value]) {
-          return true;
-        }
-      }
-      return false;
-    },
-
-    /**
-     * Build facetFilters parameter based on current refinements
-     * @param  {string} facet if set, the current disjunctive facet
-     * @return {hash}
-     */
-    _getFacetFilters: function(facet) {
-      var facetFilters = [];
-      if (this.options.defaultFacetFilters) {
-        for (var i = 0; i < this.options.defaultFacetFilters.length; ++i) {
-          facetFilters.push(this.options.defaultFacetFilters[i]);
-        }
-      }
-      for (var refinement in this.refinements) {
-        if (this.refinements[refinement]) {
-          facetFilters.push(refinement);
-        }
-      }
-      for (var refinement in this.excludes) {
-        if (this.excludes[refinement]) {
-          facetFilters.push(refinement);
-        }
-      }
-      for (var disjunctiveRefinement in this.disjunctiveRefinements) {
-        if (disjunctiveRefinement !== facet) {
-          var refinements = [];
-          for (var value in this.disjunctiveRefinements[disjunctiveRefinement]) {
-            if (this.disjunctiveRefinements[disjunctiveRefinement][value]) {
-              refinements.push(disjunctiveRefinement + ':' + value);
-            }
-          }
-          if (refinements.length > 0) {
-            facetFilters.push(refinements);
-          }
-        }
-      }
-      return facetFilters;
+  /**
+   * Build search parameters used to fetch hits
+   * @return {hash}
+   */
+  _getHitsSearchParams: function() {
+    var facets = [];
+    var i = 0;
+    for (i = 0; i < this.options.facets.length; ++i) {
+      facets.push(this.options.facets[i]);
     }
-  };
-})();
+    for (i = 0; i < this.options.disjunctiveFacets.length; ++i) {
+      var facet = this.options.disjunctiveFacets[i];
+      if (!this._hasDisjunctiveRefinements(facet)) {
+        facets.push(facet);
+      }
+    }
+    return extend({}, {
+      hitsPerPage: this.options.hitsPerPage,
+      page: this.page,
+      facets: facets,
+      facetFilters: this._getFacetFilters()
+    }, this.searchParams);
+  },
+
+  /**
+   * Build search parameters used to fetch a disjunctive facet
+   * @param  {string} facet the associated facet name
+   * @return {hash}
+   */
+  _getDisjunctiveFacetSearchParams: function(facet) {
+    return extend({}, this.searchParams, {
+      hitsPerPage: 1,
+      page: 0,
+      attributesToRetrieve: [],
+      attributesToHighlight: [],
+      attributesToSnippet: [],
+      facets: facet,
+      facetFilters: this._getFacetFilters(facet)
+    });
+  },
+
+  /**
+   * Test if there are some disjunctive refinements on the facet
+   */
+  _hasDisjunctiveRefinements: function(facet) {
+    for (var value in this.disjunctiveRefinements[facet]) {
+      if (this.disjunctiveRefinements[facet][value]) {
+        return true;
+      }
+    }
+    return false;
+  },
+
+  /**
+   * Build facetFilters parameter based on current refinements
+   * @param  {string} facet if set, the current disjunctive facet
+   * @return {hash}
+   */
+  _getFacetFilters: function(facet) {
+    var facetFilters = [];
+    if (this.options.defaultFacetFilters) {
+      for (var i = 0; i < this.options.defaultFacetFilters.length; ++i) {
+        facetFilters.push(this.options.defaultFacetFilters[i]);
+      }
+    }
+    for (var refinement in this.refinements) {
+      if (this.refinements[refinement]) {
+        facetFilters.push(refinement);
+      }
+    }
+    for (var refinement in this.excludes) {
+      if (this.excludes[refinement]) {
+        facetFilters.push(refinement);
+      }
+    }
+    for (var disjunctiveRefinement in this.disjunctiveRefinements) {
+      if (disjunctiveRefinement !== facet) {
+        var refinements = [];
+        for (var value in this.disjunctiveRefinements[disjunctiveRefinement]) {
+          if (this.disjunctiveRefinements[disjunctiveRefinement][value]) {
+            refinements.push(disjunctiveRefinement + ':' + value);
+          }
+        }
+        if (refinements.length > 0) {
+          facetFilters.push(refinements);
+        }
+      }
+    }
+    return facetFilters;
+  }
+};

--- a/src/algoliasearch.jquery.js
+++ b/src/algoliasearch.jquery.js
@@ -1,13 +1,10 @@
-/* global jQuery */
-(function ($) {
+var algoliasearch = require('../');
 
-  $.algolia = {};
-  $.algolia.Client = function(applicationID, apiKey, options) {
-    options = options || {};
-    options.jQuery = {
-      '$': $
-    };
-    return new AlgoliaSearch(applicationID, apiKey, options);
+global.jQuery.algolia = {};
+global.jQuery.algolia.Client = function(applicationID, apiKey, options) {
+  options = options || {};
+  options.jQuery = {
+    '$': global.jQuery
   };
-
-}(jQuery));
+  return algoliasearch(applicationID, apiKey, options);
+};

--- a/test/spec/algoliasearch.js
+++ b/test/spec/algoliasearch.js
@@ -1,0 +1,33 @@
+var bind = require('lodash-compat/function/bind');
+var test = require('tape');
+
+var algoliasearch = require('../../');
+
+test('algoliasearch()', function(t) {
+  t.throws(
+    algoliasearch,
+    Error,
+    'No parameters throws'
+  );
+
+  t.end();
+});
+
+test('algoliasearch(applicationID)', function(t) {
+  t.throws(
+    bind(algoliasearch, null, 'dsa'),
+    Error,
+    'Only `applicationID` throws'
+  );
+
+  t.end();
+});
+
+test('algoliasearch(applicationID, apiKey)', function(t) {
+  t.doesNotThrow(
+    bind(algoliasearch, null, 'dsa', 'hey'),
+    'Providing required parameters does not throw'
+  );
+
+  t.end();
+});

--- a/test/spec/client/initIndex.js
+++ b/test/spec/client/initIndex.js
@@ -3,14 +3,14 @@ var test = require('tape');
 test('client.initIndex()', function(t) {
   t.plan(1);
 
-  var AlgoliaSearch = require('algoliasearch');
+  var algoliasearch = require('../../../');
   var bind = require('lodash-compat/function/bind');
 
   var getCredentials = require('../../utils/get-credentials');
 
   var credentials = getCredentials();
 
-  var client = new AlgoliaSearch(credentials.applicationID, credentials.searchOnlyAPIKey);
+  var client = algoliasearch(credentials.applicationID, credentials.searchOnlyAPIKey);
 
   t.doesNotThrow(bind(client.initIndex, client, credentials.indexName));
 });

--- a/test/spec/client/interface.js
+++ b/test/spec/client/interface.js
@@ -3,16 +3,16 @@ var test = require('tape');
 // this test will ensure we are implementing a particular API method
 // If you had a new method, it will first fail, you will have to write a test
 // for it
-test('AlgoliaSearch.prototype API spec', function(t) {
+test('AlgoliaSearch client API spec', function(t) {
   t.plan(1);
 
-  var AlgoliaSearch = require('algoliasearch');
+  var algoliasearch = require('../../../');
   var filter = require('lodash-compat/collection/filter');
   var functions = require('lodash-compat/object/functions');
 
   var onlyPublicProperties = require('../../utils/only-public-properties');
 
-  var client = new AlgoliaSearch('test', 'methods');
+  var client = algoliasearch('test', 'methods');
 
   var actualMethods = filter(functions(client), onlyPublicProperties).sort();
 

--- a/test/spec/index/interface.js
+++ b/test/spec/index/interface.js
@@ -3,16 +3,16 @@ var test = require('tape');
 // this test will ensure we are implementing a particular API method
 // If you had a new method, it will first fail, you will have to write a test
 // for it
-test('AlgoliaSearch.prototype.Index.prototype API spec', function(t) {
+test('AlgoliaSearch index API spec', function(t) {
   t.plan(1);
 
-  var AlgoliaSearch = require('algoliasearch');
+  var algoliasearch = require('../../../');
   var filter = require('lodash-compat/collection/filter');
   var functions = require('lodash-compat/object/functions');
 
   var onlyPublicProperties = require('../../utils/only-public-properties');
 
-  var client = new AlgoliaSearch('test', 'methods');
+  var client = algoliasearch('test', 'methods');
   var index = client.initIndex('himethods');
 
   var actualMethods = filter(functions(index), onlyPublicProperties).sort();

--- a/test/spec/request-strategy/JSONP-creates-script-tags.js
+++ b/test/spec/request-strategy/JSONP-creates-script-tags.js
@@ -15,7 +15,12 @@ test('Request strategy creates and remove script tags when using JSONP', functio
   var currentURL = parse(location.href);
   var fixture = createFixture({
     clientOptions: {
-      dsnHost: currentURL.host
+      hosts: [
+        currentURL.host,
+        currentURL.host,
+        currentURL.host,
+        currentURL.host
+      ]
     },
     indexName: 'simple-JSONP-response'
   });

--- a/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
+++ b/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
@@ -10,7 +10,6 @@ test('Request strategy uses only JSONP if one XHR fails', function(t) {
   var currentURL = parse(location.href);
   var fixture = createFixture({
     clientOptions: {
-      dsnHost: currentURL.host,
       hosts: [
         currentURL.host
       ]

--- a/test/spec/request-strategy/slow-JSONP-response.js
+++ b/test/spec/request-strategy/slow-JSONP-response.js
@@ -13,13 +13,13 @@ test('Request strategy handles slow JSONP responses (no double callback)', funct
   var currentURL = parse(location.href);
   var fixture = createFixture({
     clientOptions: {
-      dsnHost: currentURL.host,
       hosts: [
+        currentURL.host,
         currentURL.host,
         currentURL.host,
         currentURL.host
       ],
-      requestTimeoutInMs: requestTimeout
+      timeout: requestTimeout
     },
     indexName: 'slow-response'
   });

--- a/test/spec/request-strategy/try-dsn-first.js
+++ b/test/spec/request-strategy/try-dsn-first.js
@@ -9,7 +9,14 @@ test('Request-strategy: Use DSN host first', function(t) {
 
   var fixture = createFixture({
     clientOptions: {
-      dsnHost: 'yawdsn.com'
+      hosts: [
+        'yawdsn.com',
+        'booya.com',
+        'booyou.com',
+        'booyi.com',
+        'boolala.com',
+        'boodibu.com'
+      ]
     }
   });
 

--- a/test/spec/request-strategy/uses-JSONP.js
+++ b/test/spec/request-strategy/uses-JSONP.js
@@ -14,13 +14,12 @@ test('Request strategy uses JSONP when all XHR timed out', function(t) {
   var currentURL = parse(location.href);
   var fixture = createFixture({
     clientOptions: {
-      dsnHost: currentURL.host,
       hosts: [
         currentURL.host,
         currentURL.host,
         currentURL.host
       ],
-      requestTimeoutInMs: requestTimeout
+      timeout: requestTimeout
     },
     indexName: 'request-strategy-uses-JSONP'
   });
@@ -66,9 +65,5 @@ test('Request strategy uses JSONP when all XHR timed out', function(t) {
      t.notOk(searchCallback.calledOnce, 'Callback not called on third request');
 
      clock.tick(requestTimeout * 3);
-     t.equal(fauxJax.requests.length, 4, 'Fourth request made');
-     t.notOk(searchCallback.calledOnce, 'Callback not called on fourth request');
-
-     clock.tick(requestTimeout * 4);
   });
 });

--- a/test/support-server/middlewares/request-strategy-uses-JSONP.js
+++ b/test/support-server/middlewares/request-strategy-uses-JSONP.js
@@ -14,8 +14,9 @@ function requestStrategyUsesJSONP() {
   router.get('/', function(req, res) {
     calls++;
 
-    // only reply to the fourth JSONP request
-    if (calls === 4) {
+    // only reply to the third JSONP request
+    // 3 custom hosts, no dsn
+    if (calls === 3) {
       res.jsonp({hello: 'man'});
     } else {
       res.jsonp({status: 500, message: 'woops!'});

--- a/test/utils/create-fixture.js
+++ b/test/utils/create-fixture.js
@@ -1,14 +1,14 @@
 module.exports = createFixture;
 
 function createFixture(opts) {
-  var AlgoliaSearch = require('algoliasearch');
+  var algoliasearch = require('../../');
   var getCredentials = require('./get-credentials');
 
   opts = opts || {};
 
   var credentials = getCredentials();
 
-  var client = new AlgoliaSearch(credentials.applicationID, credentials.searchOnlyAPIKey, opts.clientOptions);
+  var client = algoliasearch(credentials.applicationID, credentials.searchOnlyAPIKey, opts.clientOptions);
   var index = client.initIndex(opts.indexName || credentials.indexName);
 
   return {

--- a/test/utils/test-xhr-call.js
+++ b/test/utils/test-xhr-call.js
@@ -1,6 +1,6 @@
 module.exports = testXHRCall;
 
-var AlgoliaSearch = require('algoliasearch');
+var algoliasearch = require('../../');
 var fauxJax = require('faux-jax');
 var parse = require('url-parse');
 
@@ -10,7 +10,7 @@ function testXHRCall(opts) {
   var assert = opts.assert;
   var testCase = opts.testCase;
 
-  var client = new AlgoliaSearch(opts.applicationID, opts.searchOnlyAPIKey);
+  var client = algoliasearch(opts.applicationID, opts.searchOnlyAPIKey);
   var object;
   if (opts.object === 'index') {
     object = client.initIndex(opts.indexName);


### PR DESCRIPTION
BREAKING CHANGE, changed initialization from `new AlgoliaSearch()` =>
`algoliasearch()` #40
- The only exported global property is now `algoliasearch`
- `opts`:
    - `dsnHost` removed, use `hosts:[dsnHost, other hosts]`
    - `dsn` removed, use `hosts:[non-dsn-host, non-dsn-host]`
    - `requestTimeoutInMs` renamed to `timeout`
    - `method` renamed to `protocol`. Protocol should be specified as
`http:` or `https:`
    - `hosts` behavior changed, when using custom hosts:
      - no shuffling
      - no dsn host is prepended to the list
- removed `AlgoliaExplainResults`, no obvious use ATM
- calling algoliasearch() without an applicationID or apiKey will
throw
- Helper: `new AlgoliaSearchHelper()` => `algoliasearch.helper()`,
same function signature