### PR TITLE
Externalize plugins

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -19,6 +19,7 @@ browsers:
 server: ./test/support-server/index.js
 scripts:
   - /node_modules/jquery/dist/jquery.min.js
+  - /node_modules/jQuery-ajaxTransport-XDomainRequest/jquery.xdomainrequest.min.js
   - /node_modules/angular/angular.min.js
 html: ./test/template.html
 browserify:

--- a/ChangeLog
+++ b/ChangeLog
@@ -56,6 +56,11 @@ UNRELEASED
       This is in par with most asynchronous APIS accepted/de vfacto conventions.
       It helps being compatible with control flow libraries like `async` and
       helps reduce WTF moments of Node.JS developers used to cb(err, content)
+    * Externalize plugins and request implementations
+    * NEW FEATURE, All calls are now returning promises
+        - Native promises by default ()
+        - AngularJS promises for AngularJS plugin
+        - jQuery promises for jQuery plugin
 
 2015-02-03  2.9.2
     * Fixed calls to `.search(function() {})`, `.search(null, function() {})`, `.search(undefined, function() {})

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,7 +7,7 @@ UNRELEASED
     * running tests on many browsers, using saucelabs
     * refactor around `_makeXmlHttpRequestByHost` and `_makeJsonpRequestByHost`
     * remove unused opts.callback(retry, success, obj, message) in all make..Request functions
-    * BREAKING CHANGE, changed initialization from `new AlgoliaSearch()` => `algoliasearch()` #40
+    * BREAKING CHANGE: changed initialization from `new AlgoliaSearch()` => `algoliasearch()` #40
       - The only exported global property is now `algoliasearch`
       - `opts`:
         - `dsnHost` removed, use `hosts:[dsnHost, other hosts]`
@@ -20,9 +20,9 @@ UNRELEASED
       - removed `AlgoliaExplainResults`, no obvious use ATM
       - calling algoliasearch() without an applicationID or apiKey will throw
       - Helper: `new AlgoliaSearchHelper()` => `algoliasearch.helper()`, same function signature
-    * BREAKING CHANGE, no more window.ALGOLIA_VERSION
+    * BREAKING CHANGE: no more window.ALGOLIA_VERSION
       - you can find the version in algoliasearch.version
-    * UMD compatibiliy #41
+    * NEW FEATURE: UMD compatibiliy #41
       - algoliasearch can now be used with any module loader
       - build is now done with browserify
       - no more grunt
@@ -30,7 +30,7 @@ UNRELEASED
     * removed vendor/
       - vendor/json2.js now as an npm module
       - vendor/jquery.typeahead.js now on cdnjs (examples)
-    * BREAKING CHANGE, all api methods now use the (err, content) convention
+    * BREAKING CHANGE: all api methods now use the (err, content) convention
       It means that instead of doing:
         ```js
           index.search(function found(success, content) {
@@ -57,12 +57,15 @@ UNRELEASED
       It helps being compatible with control flow libraries like `async` and
       helps reduce WTF moments of Node.JS developers used to cb(err, content)
     * Externalize plugins and request implementations
-    * NEW FEATURE, All calls are now returning promises.
+    * NEW FEATURE: All calls are now returning promises.
       If there's a callback given to an API call, you won't get a promise.
       Here are the different promises implementations we use:
       - Native promises by default (https://github.com/jakearchibald/es6-promise/)
       - AngularJS promises for AngularJS plugin
       - jQuery promises for jQuery plugin
+    * FIX: do not retry when server sends 4xx or 1xx
+    * FIX: distinguish jQuery/AngularJS request timeouts from errors and thus retry when timeout
+    * FIX: JSONP fallback when jQuery/AngularJS request error
 
 2015-02-03  2.9.2
     * Fixed calls to `.search(function() {})`, `.search(null, function() {})`, `.search(undefined, function() {})

--- a/ChangeLog
+++ b/ChangeLog
@@ -57,10 +57,12 @@ UNRELEASED
       It helps being compatible with control flow libraries like `async` and
       helps reduce WTF moments of Node.JS developers used to cb(err, content)
     * Externalize plugins and request implementations
-    * NEW FEATURE, All calls are now returning promises
-        - Native promises by default ()
-        - AngularJS promises for AngularJS plugin
-        - jQuery promises for jQuery plugin
+    * NEW FEATURE, All calls are now returning promises.
+      If there's a callback given to an API call, you won't get a promise.
+      Here are the different promises implementations we use:
+      - Native promises by default (https://github.com/jakearchibald/es6-promise/)
+      - AngularJS promises for AngularJS plugin
+      - jQuery promises for jQuery plugin
 
 2015-02-03  2.9.2
     * Fixed calls to `.search(function() {})`, `.search(null, function() {})`, `.search(undefined, function() {})

--- a/examples/instantsearch+faceting.html
+++ b/examples/instantsearch+faceting.html
@@ -61,8 +61,8 @@
           index.search($inputfield.val(), searchCallback, { facets: '*', facetFilters: filters });
         }
 
-        function searchCallback(success, content) {
-          if (!success) {
+        function searchCallback(err, content) {
+          if (err) {
             // error
             return;
           }

--- a/examples/instantsearch+faceting.html
+++ b/examples/instantsearch+faceting.html
@@ -71,7 +71,7 @@
             // do not consider out-dated queries
             return;
           }
-          if (content.hits.length == 0 || content.query.trim() === '') {
+          if (content.hits.length == 0 || $.trim(content.query) === '') {
             // no results
             $('#hits').empty();
             $('#facets').empty();

--- a/examples/instantsearch+helper+excludes.html
+++ b/examples/instantsearch+helper+excludes.html
@@ -75,8 +75,8 @@
           }
         }
 
-        function searchCallback(success, content) {
-          if (!success) {
+        function searchCallback(err, content) {
+          if (err) {
             // error
             return;
           }

--- a/examples/instantsearch+helper.html
+++ b/examples/instantsearch+helper.html
@@ -72,8 +72,8 @@
           }
         }
 
-        function searchCallback(success, content) {
-          if (!success) {
+        function searchCallback(err, content) {
+          if (err) {
             // error
             return;
           }

--- a/examples/instantsearch+pagination.html
+++ b/examples/instantsearch+pagination.html
@@ -39,8 +39,8 @@
         var index = client.initIndex('contacts');
 
         // callback called on each query
-        function searchCallback(success, content) {
-          if (!success) {
+        function searchCallback(err, content) {
+          if (err) {
             // error
             return;
           }

--- a/examples/instantsearch.html
+++ b/examples/instantsearch.html
@@ -28,8 +28,8 @@
     <div id="hits"></div>
 
     <script type="text/javascript">
-      function searchCallback(success, content) {
-        if (!success) {
+      function searchCallback(err, content) {
+        if (err) {
           // error
           return;
         }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,4 @@
-module.exports = algoliasearch;
-
-function algoliasearch(applicationID, apiKey, opts) {
-  var AlgoliaSearch = require('./src/algoliasearch');
-
-  return new AlgoliaSearch(applicationID, apiKey, opts);
-}
-
-algoliasearch.version = require('./package.json').version;
-algoliasearch.helper = require('./src/algoliasearch.helper');
+// default entrypoint is the node module
+// this is overriden by the `browser` field in package.json
+// https://github.com/substack/node-browserify#browser-field
+module.exports = require('src/node');

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
   "version": "2.9.2",
   "dependencies": {
     "JSON2": "0.1.0",
-    "lodash-compat": "3.5.0"
+    "lodash-compat": "3.5.0",
+    "promise": "6.1.0"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "browser": "src/browser.js"
 }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   "version": "2.9.2",
   "dependencies": {
     "JSON2": "0.1.0",
-    "lodash-compat": "3.5.0",
-    "promise": "6.1.0"
+    "es6-promise": "2.0.1",
+    "lodash-compat": "3.5.0"
   },
   "main": "index.js",
   "browser": "src/browser.js"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express": "4.12.1",
     "faux-jax": "3.0.1",
     "http-server": "0.7.5",
+    "jQuery-ajaxTransport-XDomainRequest": "git://github.com/MoonScript/jQuery-ajaxTransport-XDomainRequest#1.0.4",
     "jquery": "2.1.3",
     "json": "9.0.3",
     "lodash": "3.5.0",

--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -1,13 +1,67 @@
-var algoliasearch = require('../');
+var createAlgoliasearch = require('./create-algoliasearch');
+var JSONPRequest = require('./jsonp-request');
 
 module.exports = global.angular.module('algoliasearch', [])
-  .service('algolia', ['$injector', function ($injector) {
+  .service('algolia', ['$http', '$q', function ($http, $q) {
+    function request(url, opts) {
+      return $q(function(resolve, reject) {
+        var body = null;
+
+        if (opts.body !== undefined) {
+          body = JSON.stringify(opts.body);
+        }
+
+        $http({
+          url: url,
+          method: opts.method,
+          data: body,
+          cache: false,
+          timeout: opts.timeout
+        }).then(function success(response) {
+          resolve({
+            statusCode: response.status,
+            body: response.data
+          });
+        }, function error(response) {
+          // network error or timeout
+          if (response.status === 0) {
+            reject(new Error('Network error or timeout'));
+            return;
+          }
+
+          resolve({
+            body: response.data,
+            statusCode: response.status
+          });
+        });
+      });
+    }
+
+    request.fallback = function(url, opts) {
+      return $q(function(resolve, reject) {
+        JSONPRequest(url, opts, function JSONPRequestDone(err, content) {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve(content);
+        });
+      });
+    };
+
+    request.reject = function(val) {
+      return $q.reject(val);
+    };
+
+    request.resolve = function(val) {
+      // http://www.bennadel.com/blog/2735-q-when-is-the-missing-q-resolve-method-in-angularjs.htm
+      return $q.when(val);
+    };
+
+    var algoliasearch = createAlgoliasearch(request);
     return {
       Client: function(applicationID, apiKey, options) {
-        options = options || {};
-        options.angular = {
-          '$injector': $injector
-        };
         return algoliasearch(applicationID, apiKey, options);
       }
     };

--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -2,7 +2,7 @@ var createAlgoliasearch = require('./create-algoliasearch');
 var JSONPRequest = require('./jsonp-request');
 
 global.angular.module('algoliasearch', [])
-  .service('algolia', ['$http', '$q', function ($http, $q) {
+  .service('algolia', ['$http', '$q', '$timeout', function ($http, $q, $timeout) {
     function request(url, opts) {
       return $q(function(resolve, reject) {
         var body = null;
@@ -57,6 +57,12 @@ global.angular.module('algoliasearch', [])
     request.resolve = function(val) {
       // http://www.bennadel.com/blog/2735-q-when-is-the-missing-q-resolve-method-in-angularjs.htm
       return $q.when(val);
+    };
+
+    request.delay = function(ms) {
+      return $q(function(resolve/*, reject*/) {
+        $timeout(resolve, ms);
+      });
     };
 
     var algoliasearch = createAlgoliasearch(request);

--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -1,7 +1,7 @@
 var createAlgoliasearch = require('./create-algoliasearch');
 var JSONPRequest = require('./jsonp-request');
 
-module.exports = global.angular.module('algoliasearch', [])
+global.angular.module('algoliasearch', [])
   .service('algolia', ['$http', '$q', function ($http, $q) {
     function request(url, opts) {
       return $q(function(resolve, reject) {

--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -18,7 +18,7 @@ global.angular.module('algoliasearch', [])
             // will cancel the xhr
             resolveTimeout('test');
             resolve(new Error('Timeout - Could not connect to endpoint ' + url));
-          }, 1000);
+          }, opts.timeout);
         });
 
         $http({

--- a/src/algoliasearch.helper.js
+++ b/src/algoliasearch.helper.js
@@ -327,8 +327,8 @@ AlgoliaSearchHelper.prototype = {
       this.client.addQueryInBatch(this.extraQueries[i].index, this.extraQueries[i].query, this.extraQueries[i].params);
     }
     var self = this;
-    this.client.sendQueriesBatch(function(success, content) {
-      if (!success) {
+    this.client.sendQueriesBatch(function(err, content) {
+      if (err) {
         self.searchCallback(false, content);
         return;
       }

--- a/src/algoliasearch.jquery.js
+++ b/src/algoliasearch.jquery.js
@@ -19,9 +19,14 @@ function request(url, opts) {
       timeout: opts.timeout,
       dataType: 'json',
       data: body,
-      complete: function(jqXHR/*, textStatus , error*/) {
+      complete: function(jqXHR, textStatus/* , error*/) {
+        if (textStatus === 'timeout') {
+          deferred.resolve(new Error('Timeout - Could not connect to endpoint ' + url));
+          return;
+        }
+
         if (jqXHR.status === 0) {
-          deferred.reject(new Error('Network error or timeout'));
+          deferred.reject(new Error('Network error'));
           return;
         }
 

--- a/src/algoliasearch.jquery.js
+++ b/src/algoliasearch.jquery.js
@@ -1,10 +1,60 @@
-var algoliasearch = require('../');
+var createAlgoliasearch = require('./create-algoliasearch');
+var JSONPRequest = require('./jsonp-request');
 
-global.jQuery.algolia = {};
-global.jQuery.algolia.Client = function(applicationID, apiKey, options) {
-  options = options || {};
-  options.jQuery = {
-    '$': global.jQuery
-  };
-  return algoliasearch(applicationID, apiKey, options);
+var algoliasearch = createAlgoliasearch(request);
+var $ = global.jQuery
+
+$.algolia = {Client: algoliasearch};
+
+function request(url, opts) {
+  return $.Deferred(function(deferred) {
+    var body = null;
+
+    if (opts.body !== undefined) {
+      body = JSON.stringify(opts.body);
+    }
+
+    $.ajax(url, {
+      type: opts.method,
+      timeout: opts.timeout,
+      dataType: 'json',
+      data: body,
+      complete: function(jqXHR/*, textStatus , error*/) {
+        if (jqXHR.status === 0) {
+          deferred.reject(new Error('Network error or timeout'));
+          return;
+        }
+
+        deferred.resolve({
+          statusCode: jqXHR.status,
+          body: jqXHR.responseJSON
+        });
+      }
+    });
+  }).promise();
+}
+
+request.fallback = function(url, opts) {
+  return $.Deferred(function(deferred) {
+    JSONPRequest(url, opts, function JSONPRequestDone(err, content) {
+      if (err) {
+        deferred.reject(err);
+        return;
+      }
+
+      deferred.resolve(content);
+    });
+  }).promise();
+};
+
+request.reject = function(val) {
+  return $.Deferred(function(deferred) {
+    deferred.reject(val);
+  }).promise();
+};
+
+request.resolve = function(val) {
+  return $.Deferred(function(deferred) {
+    deferred.resolve(val);
+  }).promise();
 };

--- a/src/algoliasearch.jquery.js
+++ b/src/algoliasearch.jquery.js
@@ -58,3 +58,11 @@ request.resolve = function(val) {
     deferred.resolve(val);
   }).promise();
 };
+
+request.delay = function(ms) {
+  return $.Deferred(function(deferred) {
+    setTimeout(function() {
+      deferred.resolve();
+    }, ms);
+  }).promise();
+};

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -469,14 +469,17 @@ AlgoliaSearch.prototype = {
       })
       .then(function success(httpResponse) {
         var status =
-          httpResponse.statusCode ||
-
           // When in browser mode, using XDR or JSONP
           // We rely on our own API response `status`, only
           // provided when an error occurs, we also expect a .message along
           // Otherwise, it could be a `waitTask` status, that's the only
           // case where we have a response.status that's not the http statusCode
           httpResponse && httpResponse.body && httpResponse.body.message && httpResponse.body.status ||
+
+          // this is important to check the request statusCode AFTER the body eventual
+          // statusCode because some implementations (jQuery XDomainRequest transport) may
+          // send statusCode 200 while we had an error
+          httpResponse.statusCode ||
 
           // When in browser mode, using XDR or JSONP
           // we default to success when no error (no response.status && response.message)

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -526,7 +526,12 @@ AlgoliaSearch.prototype = {
         if (!client.forceFallback) {
           // next time doRequest is called, simulate we tried all hosts
           tries = client.hosts.length;
+        } else {
+          // we were already using the fallback, but something went wrong (script error)
+          client.currentHostIndex = ++client.currentHostIndex % client.hosts.length;
+          tries += 1;
         }
+
         return doRequest(requester, reqOpts);
       }
     }

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -68,12 +68,6 @@ function AlgoliaSearch(applicationID, apiKey, opts, _request) {
     return opts.protocol + '//' + host;
   });
 
-  // jQuery plugin
-  // see https://github.com/algolia/algoliasearch-client-js/issues/44
-  if (opts.jQuery) {
-    this._jQuery = opts.jQuery;
-  }
-
   this.applicationID = applicationID;
   this.apiKey = apiKey;
   this.hosts = opts.hosts;
@@ -437,7 +431,7 @@ AlgoliaSearch.prototype = {
         if (!opts.fallback || requester === client._request.fallback) {
           // could not get a response even using the fallback if one was available
           return client._request.reject(new Error(
-            'Cannot connect the Algolia\'s Search API.' +
+            'Cannot connect to the AlgoliaSearch API.' +
             ' Send an email to support@algolia.com to report and resolve the issue.'
           ));
         }
@@ -547,49 +541,6 @@ AlgoliaSearch.prototype = {
     } else {
       return promise;
     }
-  },
-
-  /**
-   * Make a $.ajax
-   *
-   * @param url request url (includes endpoint and path)
-   * @param opts all request opts
-   */
-  _makejQueryRequestByHost: function(url, opts) {
-    var body = null;
-
-    if (!this._isUndefined(opts.body)) {
-      body = JSON2.stringify(opts.body);
-    }
-
-    url += (url.indexOf('?') === -1 ? '?' : '&') + 'X-Algolia-API-Key=' + this.apiKey;
-    url += '&X-Algolia-Application-Id=' + this.applicationID;
-    if (this.userToken) {
-      url += '&X-Algolia-UserToken=' + encodeURIComponent(this.userToken);
-    }
-    if (this.tagFilters) {
-      url += '&X-Algolia-TagFilters=' + encodeURIComponent(this.tagFilters);
-    }
-    for (var i = 0; i < this.extraHeaders.length; ++i) {
-      url += '&' + this.extraHeaders[i].key + '=' + this.extraHeaders[i].value;
-    }
-    this._jQuery.$.ajax(url, {
-      type: opts.method,
-      timeout: this.requestTimeout * (opts.successiveRetryCount + 1),
-      dataType: 'json',
-      data: body,
-      complete: function(jqXHR/*, textStatus , error*/) {
-        if (jqXHR.status === 0) {
-          opts.callback(new Error('Network error or timeout'));
-          return;
-        }
-
-        opts.callback(null, {
-          statusCode: jqXHR.status,
-          body: jqXHR.responseJSON
-        });
-      }
-    });
   },
 
    /*

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -68,17 +68,6 @@ function AlgoliaSearch(applicationID, apiKey, opts, _request) {
     return opts.protocol + '//' + host;
   });
 
-  // AngularJS plugin
-  // dependencies injection
-  // see https://github.com/algolia/algoliasearch-client-js/issues/44
-  if (opts.angular) {
-    this._angular = opts.angular;
-    opts.angular.$injector.invoke(['$http', '$q', function ($http, $q) {
-      opts.angular.$q = $q;
-      opts.angular.$http = $http;
-    }]);
-  }
-
   // jQuery plugin
   // see https://github.com/algolia/algoliasearch-client-js/issues/44
   if (opts.jQuery) {
@@ -558,55 +547,6 @@ AlgoliaSearch.prototype = {
     } else {
       return promise;
     }
-  },
-
-  /**
-   * Make a $http
-   *
-   * @param url request url (includes endpoint and path)
-   * @param opts all request opts
-   */
-  _makeAngularRequestByHost: function(url, opts) {
-    var body = null;
-
-    if (!this._isUndefined(opts.body)) {
-      body = JSON2.stringify(opts.body);
-    }
-
-    url += (url.indexOf('?') === -1 ? '?' : '&') + 'X-Algolia-API-Key=' + this.apiKey;
-    url += '&X-Algolia-Application-Id=' + this.applicationID;
-    if (this.userToken) {
-      url += '&X-Algolia-UserToken=' + encodeURIComponent(this.userToken);
-    }
-    if (this.tagFilters) {
-      url += '&X-Algolia-TagFilters=' + encodeURIComponent(this.tagFilters);
-    }
-    for (var i = 0; i < this.extraHeaders.length; ++i) {
-      url += '&' + this.extraHeaders[i].key + '=' + this.extraHeaders[i].value;
-    }
-    this._angular.$http({
-      url: url,
-      method: opts.method,
-      data: body,
-      cache: false,
-      timeout: this.requestTimeout * (opts.successiveRetryCount + 1)
-    }).then(function success(response) {
-      opts.callback(null, {
-        statusCode: response.status,
-        body: response.data
-      });
-    }, function error(response) {
-      // network error or timeout
-      if (response.status === 0) {
-        opts.callback(new Error('Network error or timeout'));
-        return;
-      }
-
-      opts.callback(null, {
-        body: response.data,
-        statusCode: response.status
-      });
-    });
   },
 
   /**

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -735,10 +735,16 @@ AlgoliaSearch.prototype.Index.prototype = {
    *  content: the server answer that contains 3 elements: createAt, taskId and objectID
    */
   deleteObject: function(objectID, callback) {
-    if (objectID === null || objectID.length === 0) {
-      callback(false, { message: 'empty objectID'});
-      return;
+    if (typeof objectID === 'function' || typeof objectID !== 'string' && typeof objectID !== 'number') {
+      var err = new Error('Cannot delete an object without an objectID');
+      callback = objectID;
+      if (typeof callback === 'function') {
+        return callback(err);
+      }
+
+      return this.as._request.reject(err);
     }
+
     var indexObj = this;
     return this.as._jsonRequest({ method: 'DELETE',
                  url: '/1/indexes/' + encodeURIComponent(indexObj.indexName) + '/' + encodeURIComponent(objectID),

--- a/src/algoliasearch.js
+++ b/src/algoliasearch.js
@@ -397,45 +397,22 @@ AlgoliaSearch.prototype = {
   },
 
   _sendQueriesBatch: function(params, callback) {
-     if (this.jsonp === null) {
-      var self = this;
-      return this._jsonRequest({ cache: this.cache,
-        method: 'POST',
-        url: '/1/indexes/*/queries',
-        body: params,
-        callback: function(err, content) {
-          if (err) {
-            // retry first with JSONP
-            self.jsonp = true;
-            self._sendQueriesBatch(params, callback);
-            return;
-          }
-
-          self.jsonp = false;
-          callback && callback(null, content);
-        }
-      });
-    } else if (this.jsonp) {
-      var jsonpParams = '';
-      for (var i = 0; i < params.requests.length; ++i) {
-        var q = '/1/indexes/' + encodeURIComponent(params.requests[i].indexName) + '?' + params.requests[i].params;
-        jsonpParams += i + '=' + encodeURIComponent(q) + '&';
-      }
-      var pObj = {params: jsonpParams};
-      return this._jsonRequest({
-        cache: this.cache,
-        method: 'GET',
-        url: '/1/indexes/*',
-        body: pObj,
-        callback: callback
-      });
-    }
-
-    return this._jsonRequest({
-      cache: this.cache,
+    return this._jsonRequest({ cache: this.cache,
       method: 'POST',
       url: '/1/indexes/*/queries',
       body: params,
+      fallback: {
+        method: 'GET',
+        url: '/1/indexes/*',
+        body: {params: (function() {
+          var jsonpParams = '';
+          for (var i = 0; i < params.requests.length; ++i) {
+            var q = '/1/indexes/' + encodeURIComponent(params.requests[i].indexName) + '?' + params.requests[i].params;
+            jsonpParams += i + '=' + encodeURIComponent(q) + '&';
+          }
+          return jsonpParams;
+        }())}
+      },
       callback: callback
     });
   },
@@ -449,6 +426,7 @@ AlgoliaSearch.prototype = {
     // if fallback used and no more tries, return error
     // fallback parameters are in opts.fallback
     // call request.fallback or request accordingly, same promise chain otherwise
+    // put callback& params in front if problem
     var cache = opts.cache;
     var cacheID = opts.url;
     var client = this;
@@ -460,13 +438,31 @@ AlgoliaSearch.prototype = {
       cacheID += '_body_' + JSON2.stringify(opts.body);
     }
 
-    function doRequest() {
+    function doRequest(requester, reqOpts) {
       // handle cache existence
       if (cache && cache[cacheID] !== undefined) {
         return client._request.resolve(cache[cacheID]);
       }
 
-      var url = opts.url;
+      if (tries >= client.hosts.length) {
+        if (!opts.fallback || requester === client._request.fallback) {
+          // could not get a response even using the fallback if one was available
+          return client._request.reject(new Error(
+            'Cannot connect the Algolia\'s Search API.' +
+            ' Send an email to support@algolia.com to report and resolve the issue.'
+          ));
+        }
+
+        tries = 0;
+        reqOpts.method = opts.fallback.method;
+        reqOpts.url = opts.fallback.url;
+        reqOpts.body = opts.fallback.body;
+        reqOpts.timeout = client.requestTimeout * (tries + 1);
+        client.forceFallback = true;
+        return doRequest(client._request.fallback, reqOpts);
+      }
+
+      var url = reqOpts.url;
 
       url += (url.indexOf('?') === -1 ? '?' : '&') + 'X-Algolia-API-Key=' + client.apiKey;
       url += '&X-Algolia-Application-Id=' + client.applicationID;
@@ -483,72 +479,82 @@ AlgoliaSearch.prototype = {
         url += '&' + client.extraHeaders[i].key + '=' + client.extraHeaders[i].value;
       }
 
-      if (tries > client.hosts.length) {
-        return client.request.reject(new Error(
-          'Cannot connect the Algolia\'s Search API.' +
-          ' Send an email to support@algolia.com to report and resolve the issue.'
-        ));
+      return requester(client.hosts[client.currentHostIndex] + url, {
+        body: reqOpts.body,
+        method: reqOpts.method,
+        timeout: reqOpts.timeout
+      })
+      .then(function success(httpResponse) {
+        var status =
+          httpResponse.statusCode ||
+
+          // When in browser mode, using XDR or JSONP
+          // We rely on our own API response `status`, only
+          // provided when an error occurs, we also expect a .message along
+          // Otherwise, it could be a `waitTask` status, that's the only
+          // case where we have a response.status that's not the http statusCode
+          httpResponse && httpResponse.body && httpResponse.body.message && httpResponse.body.status ||
+
+          // When in browser mode, using XDR or JSONP
+          // we default to success when no error (no response.status && response.message)
+          // If there was a JSON.parse() error then body is null and it fails
+          httpResponse && httpResponse.body && 200;
+
+        var ok = status === 200 || status === 201;
+        var retry = !ok && status !== 400 && status !== 403 && status !== 404;
+
+        if (ok && cache) {
+          cache[cacheID] = httpResponse.body;
+        }
+
+        if (ok) {
+          return httpResponse.body;
+        }
+
+        if (retry) {
+          return retryRequest();
+        }
+
+        var unrecoverableError = new Error(
+          httpResponse.body && httpResponse.body.message || 'Unknown error'
+        );
+
+        return client._request.reject(unrecoverableError);
+      }, retryRequest);
+
+      function retryRequest() {
+        client.currentHostIndex = ++client.currentHostIndex % client.hosts.length;
+        tries += 1;
+        reqOpts.timeout = client.requestTimeout * (tries + 1);
+        return doRequest(requester, reqOpts);
       }
-
-      return client._request(client.hosts[client.currentHostIndex] + url, {
-          body: opts.body,
-          method: opts.method,
-          timeout: client.requestTimeout * (tries + 1)
-        })
-        .then(function success(httpResponse) {
-          var status =
-            httpResponse.statusCode ||
-
-            // When in browser mode, using XDR or JSONP
-            // We rely on our own API response `status`, only
-            // provided when an error occurs, we also expect a .message along
-            // Otherwise, it could be a `waitTask` status, that's the only
-            // case where we have a response.status that's not the http statusCode
-            httpResponse && httpResponse.body && httpResponse.body.message && httpResponse.body.status ||
-
-            // When in browser mode, using XDR or JSONP
-            // we default to success when no error (no response.status && response.message)
-            // If there was a JSON.parse() error then body is null and it fails
-            httpResponse && httpResponse.body && 200;
-
-          var ok = status === 200 || status === 201;
-          var retry = !ok && status !== 400 && status !== 403 && status !== 404;
-
-          if (ok && cache) {
-            cache[cacheID] = httpResponse.body;
-          }
-
-          if (ok) {
-            return httpResponse.body;
-          }
-
-          if (retry) {
-            client.currentHostIndex = ++client.currentHostIndex % client.hosts.length;
-            tries += 1;
-            return doRequest();
-          }
-
-          var unrecoverableError = new Error(
-            httpResponse.body && httpResponse.body.message || 'Unknown error'
-          );
-
-          return client.request.reject(unrecoverableError);
-        }, function failure(/*err*/) {
-          // Timeout or network problem, always retry
-          client.currentHostIndex = ++client.currentHostIndex % client.hosts.length;
-          tries += 1;
-          return doRequest();
-        });
     }
 
-    var promise = doRequest();
+    // we can use a fallback if forced AND fallback parameters are available
+    var useFallback = client.forceFallback && opts.fallback;
+    var requestOptions = useFallback ? opts.fallback : opts;
+
+    var promise = doRequest(
+      useFallback ? client._request.fallback : client._request, {
+        url: requestOptions.url,
+        method: requestOptions.method,
+        body: requestOptions.body,
+        timeout: client.requestTimeout * (tries + 1)
+      }
+    );
 
     // either we have a callback
     // either we are using promises
     if (opts.callback) {
       promise.then(function okCb(content) {
-        opts.callback(null, content);
-      }, opts.callback);
+        process.nextTick(function() {
+          opts.callback(null, content);
+        });
+      }, function nookCb(err) {
+        process.nextTick(function() {
+          opts.callback(err);
+        });
+      });
     } else {
       return promise;
     }
@@ -644,136 +650,6 @@ AlgoliaSearch.prototype = {
         });
       }
     });
-  },
-
-  /**
-   * Make a JSONP request
-   *
-   * @param url request url (includes endpoint and path)
-   * @param opts all request options
-   */
-  _makeJsonpRequestByHost: function(url, opts) {
-    if (opts.method !== 'GET') {
-      opts.callback(new Error('Method ' + opts.method + ' ' + url + ' is not supported by JSONP.'));
-      return;
-    }
-
-    var cbCalled = false;
-    var timedOut = false;
-
-    AlgoliaSearch.JSONPCounter += 1;
-    var head = document.getElementsByTagName('head')[0];
-    var script = document.createElement('script');
-    var cb = 'algoliaJSONP_' + AlgoliaSearch.JSONPCounter;
-    var done = false;
-    var ontimeout;
-    var success;
-    var clean;
-
-    window[cb] = function(data) {
-      try {
-        delete window[cb];
-      } catch (e) {
-        window[cb] = undefined;
-      }
-
-      if (timedOut) {
-        return;
-      }
-
-      cbCalled = true;
-
-      clean();
-
-      opts.callback(null, {
-        body: data/*,
-        // We do not send the statusCode, there's no statusCode in JSONP, it will be
-        // computed using data.status && data.message like with XDR
-        statusCode*/
-      });
-    };
-
-    url += '?callback=' + cb + '&X-Algolia-Application-Id=' + this.applicationID + '&X-Algolia-API-Key=' + this.apiKey;
-
-    if (this.tagFilters) {
-      url += '&X-Algolia-TagFilters=' + encodeURIComponent(this.tagFilters);
-    }
-
-    if (this.userToken) {
-      url += '&X-Algolia-UserToken=' + encodeURIComponent(this.userToken);
-    }
-
-    for (var i = 0; i < this.extraHeaders.length; ++i) {
-      url += '&' + this.extraHeaders[i].key + '=' + this.extraHeaders[i].value;
-    }
-
-    if (opts.body && opts.body.params) {
-      url += '&' + opts.body.params;
-    }
-
-    ontimeout = setTimeout(function timeoutListener() {
-      timedOut = true;
-      clean();
-      opts.callback(new Error('Timeout - Could not connect to endpoint ' + url));
-    }, this.requestTimeout);
-
-    success = function() {
-      if (done || timedOut) {
-        return;
-      }
-
-      done = true;
-
-      // script loaded but did not call the fn => script loading error
-      if (!cbCalled) {
-        clean();
-        opts.callback(new Error('Failed to load JSONP script'));
-      }
-    };
-
-    clean = function() {
-      clearTimeout(ontimeout);
-      script.onload = null;
-      script.onreadystatechange = null;
-      script.onerror = null;
-      head.removeChild(script);
-
-      try {
-        delete window[cb];
-        delete window[cb + '_loaded'];
-      } catch (e) {
-        window[cb] = null;
-        window[cb + '_loaded'] = null;
-      }
-    };
-
-    // script onreadystatechange needed only for
-    // <= IE8
-    // https://github.com/angular/angular.js/issues/4523
-    script.onreadystatechange = function() {
-      if (this.readyState === 'loaded' || this.readyState === 'complete') {
-        success();
-      }
-    };
-
-    script.onload = function() {
-      success();
-    };
-
-    script.onerror = function() {
-      if (done || timedOut) {
-        return;
-      }
-
-      clean();
-      opts.callback(new Error('Failed to load JSONP script'));
-    };
-
-    script.async = true;
-    script.defer = true;
-    script.src = url;
-
-    head.appendChild(script);
   },
 
    /*
@@ -1337,11 +1213,12 @@ AlgoliaSearch.prototype.Index.prototype = {
     return this.as._jsonRequest({ cache: this.cache,
       method: 'POST',
       url: '/1/indexes/' + encodeURIComponent(this.indexName) + '/query',
+      body: {params: params},
       fallback: {
         method: 'GET',
-        url: '/1/indexes/' + encodeURIComponent(this.indexName)
+        url: '/1/indexes/' + encodeURIComponent(this.indexName),
+        body: {params: params}
       },
-      body: {params: params},
       callback: callback
     });
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -126,3 +126,9 @@ request.reject = function(val) {
 request.resolve = function(val) {
   return Promise.resolve(val);
 };
+
+request.delay = function(ms) {
+  return new Promise(function(resolve/*, reject*/) {
+    setTimeout(resolve, ms);
+  });
+};

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,228 @@
+// this is the standalone build entry of AlgoliaSearch
+var createAlgoliasearch = require('./create-algoliasearch');
+
+module.exports = createAlgoliasearch(request);
+
+var JSON2 = require('JSON2');
+var Promise = require('promise');
+
+var JSONPCounter = 0;
+var support = {
+  hasXMLHttpRequest: 'XMLHttpRequest' in window,
+  hasXDomainRequest: 'XDomainRequest' in window,
+  cors: 'withCredentials' in new XMLHttpRequest(),
+  timeout: 'timeout' in new XMLHttpRequest()
+};
+
+function request(url, opts) {
+  return new Promise(function(resolve, reject) {
+    // no cors or XDomainRequest, no request
+    if (!support.cors && !support.hasXDomainRequest) {
+      // very old browser, not supported
+      reject(new Error('CORS not supported'));
+      return;
+    }
+
+    var body;
+    var req = support.cors ? new XMLHttpRequest() : new XDomainRequest();
+    var ontimeout;
+    var timedOut;
+
+    if (opts.body !== undefined) {
+      body = JSON2.stringify(opts.body);
+    }
+
+    req.open(opts.method, url);
+
+    if (support.cors && body && opts.method !== 'GET') {
+      req.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+    }
+
+    req.onload = load;
+    req.onerror = error;
+
+    if (support.timeout) {
+      // .timeout supported by both XHR and XDR,
+      // we do receive timeout event, tested
+      req.timeout = opts.timeout;
+
+      req.ontimeout = timeout;
+    } else {
+      ontimeout = setTimeout(timeout, opts.timeout);
+    }
+
+    req.send(body);
+
+    // event object not received in IE8, at least
+    // but we do not use it, still important to note
+    function load(/*event*/) {
+      // When browser does not supports req.timeout, we can
+      // have both a load and timeout event, since handled by a dumb setTimeout
+      if (timedOut) {
+        return;
+      }
+
+      if (!support.timeout) {
+        clearTimeout(ontimeout);
+      }
+
+      var response = null;
+
+      try {
+        response = JSON2.parse(req.responseText);
+      } catch(e) {}
+
+      resolve({
+        body: response,
+        statusCode: req.status
+      });
+    }
+
+    function error(event) {
+      if (timedOut) {
+        return;
+      }
+
+      if (!support.timeout) {
+        clearTimeout(ontimeout);
+      }
+
+      // error event is trigerred both with XDR/XHR on:
+      //   - DNS error
+      //   - unallowed cross domain request
+      reject(new Error('Could not connect to host, error was:' + event));
+    }
+
+    function timeout() {
+      if (!support.timeout) {
+        timedOut = true;
+        req.abort();
+      }
+
+      reject(new Error('Timeout - Could not connect to endpoint ' + url));
+    }
+
+  });
+}
+
+request.fallback = function(url, opts) {
+  return new Promise(function(resolve, reject) {
+    if (opts.method !== 'GET') {
+      reject(new Error('Method ' + opts.method + ' ' + url + ' is not supported by JSONP.'));
+      return;
+    }
+
+    var cbCalled = false;
+    var timedOut = false;
+
+    JSONPCounter += 1;
+    var head = document.getElementsByTagName('head')[0];
+    var script = document.createElement('script');
+    var cbName = 'algoliaJSONP_' + JSONPCounter;
+    var done = false;
+
+    window[cbName] = function(data) {
+      try {
+        delete window[cbName];
+      } catch (e) {
+        window[cbName] = undefined;
+      }
+
+      if (timedOut) {
+        return;
+      }
+
+      cbCalled = true;
+
+      clean();
+
+      resolve({
+        body: data/*,
+        // We do not send the statusCode, there's no statusCode in JSONP, it will be
+        // computed using data.status && data.message like with XDR
+        statusCode*/
+      });
+    };
+
+    // add callback by hand
+    url += '&callback=' + cbName;
+
+    // add body params by hand
+    if (opts.body && opts.body.params) {
+      url += '&' + opts.body.params;
+    }
+
+    var ontimeout = setTimeout(timeout, opts.timeout);
+
+    // script onreadystatechange needed only for
+    // <= IE8
+    // https://github.com/angular/angular.js/issues/4523
+    script.onreadystatechange = readystatechange;
+    script.onload = success;
+    script.onerror = error;
+
+    script.async = true;
+    script.defer = true;
+    script.src = url;
+    head.appendChild(script);
+
+    function success() {
+      if (done || timedOut) {
+        return;
+      }
+
+      done = true;
+
+      // script loaded but did not call the fn => script loading error
+      if (!cbCalled) {
+        clean();
+        reject(new Error('Failed to load JSONP script'));
+      }
+    }
+
+    function readystatechange() {
+      if (this.readyState === 'loaded' || this.readyState === 'complete') {
+        success();
+      }
+    }
+
+    function clean() {
+      clearTimeout(ontimeout);
+      script.onload = null;
+      script.onreadystatechange = null;
+      script.onerror = null;
+      head.removeChild(script);
+
+      try {
+        delete window[cbName];
+        delete window[cbName + '_loaded'];
+      } catch (e) {
+        window[cbName] = null;
+        window[cbName + '_loaded'] = null;
+      }
+    }
+
+    function timeout() {
+      timedOut = true;
+      clean();
+      reject(new Error('Timeout - Could not connect to endpoint ' + url));
+    }
+
+    function error() {
+      if (done || timedOut) {
+        return;
+      }
+
+      clean();
+      reject(new Error('Failed to load JSONP script'));
+    }
+  });
+};
+
+request.reject = function(val) {
+  return Promise.reject(val);
+};
+
+request.resolve = function(val) {
+  return Promise.resolve(val);
+};

--- a/src/browser.js
+++ b/src/browser.js
@@ -4,7 +4,7 @@ var createAlgoliasearch = require('./create-algoliasearch');
 module.exports = createAlgoliasearch(request);
 
 var JSON2 = require('JSON2');
-var Promise = require('promise');
+var Promise = require('es6-promise').Promise;
 
 var JSONPRequest = require('./jsonp-request');
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -100,7 +100,7 @@ function request(url, opts) {
         req.abort();
       }
 
-      reject(new Error('Timeout - Could not connect to endpoint ' + url));
+      resolve(new Error('Timeout - Could not connect to endpoint ' + url));
     }
 
   });

--- a/src/create-algoliasearch.js
+++ b/src/create-algoliasearch.js
@@ -1,0 +1,17 @@
+// this file is a `factory of algoliasearch()`
+// Given a `request` param, it will provide you an AlgoliaSearch client
+// using this particular request
+module.exports = createAlgoliasearch;
+
+function createAlgoliasearch(request) {
+  function algoliasearch(applicationID, apiKey, opts) {
+    var AlgoliaSearch = require('./algoliasearch');
+
+    return new AlgoliaSearch(applicationID, apiKey, opts, request);
+  }
+
+  algoliasearch.version = require('../package.json').version;
+  algoliasearch.helper = require('./algoliasearch.helper');
+
+  return algoliasearch;
+}

--- a/src/jsonp-request.js
+++ b/src/jsonp-request.js
@@ -1,0 +1,115 @@
+module.exports = JSONPRequest;
+
+var JSONPCounter = 0;
+
+function JSONPRequest(url, opts, cb) {
+  if (opts.method !== 'GET') {
+    cb(new Error('Method ' + opts.method + ' ' + url + ' is not supported by JSONP.'));
+    return;
+  }
+
+  var cbCalled = false;
+  var timedOut = false;
+
+  JSONPCounter += 1;
+  var head = document.getElementsByTagName('head')[0];
+  var script = document.createElement('script');
+  var cbName = 'algoliaJSONP_' + JSONPCounter;
+  var done = false;
+
+  window[cbName] = function(data) {
+    try {
+      delete window[cbName];
+    } catch (e) {
+      window[cbName] = undefined;
+    }
+
+    if (timedOut) {
+      return;
+    }
+
+    cbCalled = true;
+
+    clean();
+
+    cb(null, {
+      body: data/*,
+      // We do not send the statusCode, there's no statusCode in JSONP, it will be
+      // computed using data.status && data.message like with XDR
+      statusCode*/
+    });
+  };
+
+  // add callback by hand
+  url += '&callback=' + cbName;
+
+  // add body params by hand
+  if (opts.body && opts.body.params) {
+    url += '&' + opts.body.params;
+  }
+
+  var ontimeout = setTimeout(timeout, opts.timeout);
+
+  // script onreadystatechange needed only for
+  // <= IE8
+  // https://github.com/angular/angular.js/issues/4523
+  script.onreadystatechange = readystatechange;
+  script.onload = success;
+  script.onerror = error;
+
+  script.async = true;
+  script.defer = true;
+  script.src = url;
+  head.appendChild(script);
+
+  function success() {
+    if (done || timedOut) {
+      return;
+    }
+
+    done = true;
+
+    // script loaded but did not call the fn => script loading error
+    if (!cbCalled) {
+      clean();
+      cb(new Error('Failed to load JSONP script'));
+    }
+  }
+
+  function readystatechange() {
+    if (this.readyState === 'loaded' || this.readyState === 'complete') {
+      success();
+    }
+  }
+
+  function clean() {
+    clearTimeout(ontimeout);
+    script.onload = null;
+    script.onreadystatechange = null;
+    script.onerror = null;
+    head.removeChild(script);
+
+    try {
+      delete window[cbName];
+      delete window[cbName + '_loaded'];
+    } catch (e) {
+      window[cbName] = null;
+      window[cbName + '_loaded'] = null;
+    }
+  }
+
+  function timeout() {
+    timedOut = true;
+    clean();
+    cb(new Error('Timeout - Could not connect to endpoint ' + url));
+  }
+
+  function error() {
+    if (done || timedOut) {
+      return;
+    }
+
+    clean();
+    cb(new Error('Failed to load JSONP script'));
+  }
+}

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/run.js
+++ b/test/run.js
@@ -17,23 +17,5 @@ var domready = require('domready');
 domready(run);
 
 function run() {
-  var test = require('tape');
-
-  test('simple search', function(t) {
-    var algoliasearch = require('../');
-    var client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
-    var index = client.initIndex('contacts');
-
-    index.search('atlanta', function(err, res) {
-      console.log('callback', arguments);
-    });
-
-    index.search('newyork')
-      .then(function() {
-        console.log('promise ok', arguments);
-      })
-      .catch(function() {
-        console.log('promise nope', arguments);
-      });
-  });
+  require('bulk-require')(__dirname, ['spec/**/*.js']);
 }

--- a/test/run.js
+++ b/test/run.js
@@ -17,5 +17,23 @@ var domready = require('domready');
 domready(run);
 
 function run() {
-  require('bulk-require')(__dirname, ['spec/**/*.js']);
+  var test = require('tape');
+
+  test('simple search', function(t) {
+    var algoliasearch = require('../');
+    var client = algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76');
+    var index = client.initIndex('contacts');
+
+    index.search('atlanta', function(err, res) {
+      console.log('callback', arguments);
+    });
+
+    index.search('newyork')
+      .then(function() {
+        console.log('promise ok', arguments);
+      })
+      .catch(function() {
+        console.log('promise nope', arguments);
+      });
+  });
 }

--- a/test/spec/angular.js
+++ b/test/spec/angular.js
@@ -5,7 +5,7 @@ var browser = require('bowser').browser;
 // run AngularJS test on all browsers but IE < 9
 // https://docs.angularjs.org/guide/ie
 if (!browser.msie || parseFloat(browser.version) > 8) {
-  test('AngularJS module success case', function(t) {
+  test.skip('AngularJS module success case', function(t) {
     t.plan(9);
 
     var fauxJax = require('faux-jax');

--- a/test/spec/angular.js
+++ b/test/spec/angular.js
@@ -110,7 +110,7 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
       .module('angularTestError', ['algoliasearch'])
       .controller('AngularModuleSearchControllerTestError', ['$scope', '$timeout', 'algolia', function($scope, $timeout, algolia) {
         t.pass('AngularJS controller initialized');
-        var client = algolia.Client('AngularJSError', 'ROCKSError', {timeout: 2000, hosts: ['www.truc.com']});
+        var client = algolia.Client('AngularJSError', 'ROCKSError');
         var index = client.initIndex('googleError');
         fauxJax.install();
 

--- a/test/spec/angular.js
+++ b/test/spec/angular.js
@@ -182,8 +182,6 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
         var index = client.initIndex('simple-JSONP-response');
         fauxJax.install();
 
-        // careful, cannot use .catch here, will throw in IE8
-        // even if this test does not run on IE8, it's still parsed
         index.search('angular-first').then(function searchDone(content) {
           t.deepEqual(
             content, {

--- a/test/spec/angular.js
+++ b/test/spec/angular.js
@@ -5,7 +5,7 @@ var browser = require('bowser').browser;
 // run AngularJS test on all browsers but IE < 9
 // https://docs.angularjs.org/guide/ie
 if (!browser.msie || parseFloat(browser.version) > 8) {
-  test.skip('AngularJS module success case', function(t) {
+  test('AngularJS module success case', function(t) {
     t.plan(9);
 
     var fauxJax = require('faux-jax');
@@ -106,8 +106,8 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
   // to be able to:
   //  1. do JSONP fallback even with promises
   //  1. stop JSONP fallback from runing after promise was rejected because no retry (4xx)
-  test.skip('AngularJS module error case', function(t) {
-    t.plan(3);
+  test('AngularJS module error case', function(t) {
+    t.plan(5);
 
     var fauxJax = require('faux-jax');
 
@@ -125,10 +125,20 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
         // careful, cannot use .catch here, will throw in IE8
         // even if this test does not run on IE8, it's still parsed
         index.search('SMG').then(null, function searchDone(err) {
+          t.equal(
+            err.message,
+            'Nope promise',
+            'Error message matches'
+          );
           t.ok(err instanceof Error, 'Promise was rejected');
         });
 
         index.search('BOUM', function searchDone(err) {
+          t.equal(
+            err.message,
+            'Nope callback',
+            'Error message matches'
+          );
           t.ok(err instanceof Error, 'Callback first argument is an `Error`');
         });
 
@@ -145,6 +155,71 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
     // and the required angular module (`angularTestError`) is not yet loaded
     global.angular.element(document).ready(function() {
       global.angular.bootstrap(global.angular.element('#angular-test-error'), ['angularTestError']);
+    });
+  });
+
+  test('AngularJS module JSONP fallback', function(t) {
+    t.plan(4);
+
+    var fauxJax = require('faux-jax');
+    var parse = require('url-parse');
+
+    var currentURL = parse(location.href);
+
+    // load AngularJS Algolia Search module
+    require('../../src/algoliasearch.angular');
+
+    global.angular
+      .module('angularJSONPFallback', ['algoliasearch'])
+      .controller('AngularModuleSearchControllerTestJSONPFallback', ['$scope', '$timeout', 'algolia', function($scope, $timeout, algolia) {
+        t.pass('AngularJS controller initialized');
+        var client = algolia.Client('AngularJSError', 'ROCKSError', {
+          hosts: [
+            currentURL.host
+          ],
+          timeout: 5000
+        });
+        var index = client.initIndex('simple-JSONP-response');
+        fauxJax.install();
+
+        // careful, cannot use .catch here, will throw in IE8
+        // even if this test does not run on IE8, it's still parsed
+        index.search('angular-first').then(function searchDone(content) {
+          t.deepEqual(
+            content, {
+              query: 'angular-first'
+            },
+            'Content matches'
+          );
+        });
+
+        index.search('angular-second', function searchDone(err, content) {
+          t.error(
+            err,
+            'No error while using the callback interface'
+          );
+
+          t.deepEqual(
+            content, {
+              query: 'angular-second'
+            },
+            'Content matches'
+          );
+        });
+
+        $timeout(function() {
+          fauxJax.requests[0].respond(500, {}, JSON.stringify({message: 'Nope promise'}));
+          fauxJax.requests[1].respond(500, {}, JSON.stringify({message: 'Nope callback'}));
+          fauxJax.restore();
+        });
+      }]);
+
+    // we manually bootstrap our application
+    // we cannot use ng-app in the test/template.html
+    // otherwise angular tries to initialize the app as soon as domready
+    // and the required angular module (`angularJSONPFallback`) is not yet loaded
+    global.angular.element(document).ready(function() {
+      global.angular.bootstrap(global.angular.element('#angular-JSONP-fallback'), ['angularJSONPFallback']);
     });
   });
 }

--- a/test/spec/angular.js
+++ b/test/spec/angular.js
@@ -93,19 +93,11 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
         });
       }]);
 
-    // we manually bootstrap our application
-    // we cannot use ng-app in the test/template.html
-    // otherwise angular tries to initialize the app as soon as domready
-    // and the required angular module (`angularTest`) is not yet loaded
     global.angular.element(document).ready(function() {
       global.angular.bootstrap(global.angular.element('#angular-test-success'), ['angularTestSuccess']);
     });
   });
 
-  // broken, need to switch jsonp based on an option directly from the jsonRequest() call
-  // to be able to:
-  //  1. do JSONP fallback even with promises
-  //  1. stop JSONP fallback from runing after promise was rejected because no retry (4xx)
   test('AngularJS module error case', function(t) {
     t.plan(5);
 
@@ -118,7 +110,7 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
       .module('angularTestError', ['algoliasearch'])
       .controller('AngularModuleSearchControllerTestError', ['$scope', '$timeout', 'algolia', function($scope, $timeout, algolia) {
         t.pass('AngularJS controller initialized');
-        var client = algolia.Client('AngularJSError', 'ROCKSError');
+        var client = algolia.Client('AngularJSError', 'ROCKSError', {timeout: 2000, hosts: ['www.truc.com']});
         var index = client.initIndex('googleError');
         fauxJax.install();
 
@@ -149,10 +141,6 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
         });
       }]);
 
-    // we manually bootstrap our application
-    // we cannot use ng-app in the test/template.html
-    // otherwise angular tries to initialize the app as soon as domready
-    // and the required angular module (`angularTestError`) is not yet loaded
     global.angular.element(document).ready(function() {
       global.angular.bootstrap(global.angular.element('#angular-test-error'), ['angularTestError']);
     });
@@ -212,10 +200,6 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
         });
       }]);
 
-    // we manually bootstrap our application
-    // we cannot use ng-app in the test/template.html
-    // otherwise angular tries to initialize the app as soon as domready
-    // and the required angular module (`angularJSONPFallback`) is not yet loaded
     global.angular.element(document).ready(function() {
       global.angular.bootstrap(global.angular.element('#angular-JSONP-fallback'), ['angularJSONPFallback']);
     });

--- a/test/spec/client/clearCache.js
+++ b/test/spec/client/clearCache.js
@@ -19,7 +19,7 @@ test('client.clearCache()', function(t) {
 
   // store the query in the cache
   client.startQueriesBatch();
-  client.sendQueriesBatch();
+  client.sendQueriesBatch(makeSecondRequest);
   fauxJax.requests[0].respond(200, {}, '{}');
   t.equal(
     fauxJax.requests.length,
@@ -27,27 +27,31 @@ test('client.clearCache()', function(t) {
     'One request done'
   );
 
-  // same request again
-  client.startQueriesBatch();
-  client.sendQueriesBatch();
-  t.equal(
-    fauxJax.requests.length,
-    1,
-    'Still one request done'
-  );
+  function makeSecondRequest() {
+    // same request again
+    client.startQueriesBatch();
+    client.sendQueriesBatch(makeThirdRequest);
+    t.equal(
+      fauxJax.requests.length,
+      1,
+      'Still one request done'
+    );
+  }
 
-  client.clearCache();
+  function makeThirdRequest() {
+    client.clearCache();
 
-  // same request again
-  client.startQueriesBatch();
-  client.sendQueriesBatch();
+    // same request again
+    client.startQueriesBatch();
+    client.sendQueriesBatch();
 
-  fauxJax.requests[1].respond(200, {}, '{}');
-  t.equal(
-    fauxJax.requests.length,
-    2,
-    'Second request done'
-  );
+    fauxJax.requests[1].respond(200, {}, '{}');
+    t.equal(
+      fauxJax.requests.length,
+      2,
+      'Second request done'
+    );
 
-  fauxJax.restore();
+    fauxJax.restore();
+  }
 });

--- a/test/spec/index/clearCache.js
+++ b/test/spec/index/clearCache.js
@@ -18,7 +18,8 @@ test('index.clearCache()', function(t) {
   );
 
   // store the query in the cache
-  index.search('hey!');
+  index.search('hey!', makeSecondRequest);
+
   fauxJax.requests[0].respond(200, {}, '{}');
   t.equal(
     fauxJax.requests.length,
@@ -26,24 +27,30 @@ test('index.clearCache()', function(t) {
     'One request done'
   );
 
-  // same request again
-  index.search('hey!');
-  t.equal(
-    fauxJax.requests.length,
-    1,
-    'Still one request done'
-  );
+  function makeSecondRequest() {
+    // same request again
+    index.search('hey!', makeThirdRequest);
 
-  index.clearCache();
+    t.equal(
+      fauxJax.requests.length,
+      1,
+      'Still one request done'
+    );
+  }
 
-  // same request again
-  index.search('hey!');
-  fauxJax.requests[1].respond(200, {}, '{}');
-  t.equal(
-    fauxJax.requests.length,
-    2,
-    'Second request done'
-  );
+  function makeThirdRequest() {
+    index.clearCache();
 
-  fauxJax.restore();
+    // same request again
+    index.search('hey!');
+    fauxJax.requests[1].respond(200, {}, '{}');
+    t.equal(
+      fauxJax.requests.length,
+      2,
+      'Second request done'
+    );
+
+    fauxJax.restore();
+  }
+
 });

--- a/test/spec/index/deleteObject.js
+++ b/test/spec/index/deleteObject.js
@@ -2,11 +2,13 @@ var test = require('tape');
 
 test('deleteObject()', function(t) {
   t.plan(2);
+  var bind = require('lodash-compat/function/bind');
+
   var createFixture = require('../../utils/create-fixture');
   var fixture = createFixture();
   var index = fixture.index;
 
-  index.deleteObject().then(t.fail.bind(t), function(err) {
+  index.deleteObject().then(bind(t.fail, t), function(err) {
     t.ok(err instanceof Error);
     t.equal(
       err.message,

--- a/test/spec/index/deleteObject.js
+++ b/test/spec/index/deleteObject.js
@@ -1,0 +1,31 @@
+var test = require('tape');
+
+test('deleteObject()', function(t) {
+  t.plan(2);
+  var createFixture = require('../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  index.deleteObject().then(t.fail.bind(t), function(err) {
+    t.ok(err instanceof Error);
+    t.equal(
+      err.message,
+      'Cannot delete an object without an objectID'
+    );
+  });
+});
+
+test('deleteObject(cb)', function(t) {
+  t.plan(2);
+  var createFixture = require('../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  index.deleteObject(function(err) {
+    t.ok(err instanceof Error);
+    t.equal(
+      err.message,
+      'Cannot delete an object without an objectID'
+    );
+  });
+});

--- a/test/spec/index/ttAdapter/with-params.js
+++ b/test/spec/index/ttAdapter/with-params.js
@@ -32,9 +32,9 @@ test('index.ttAdapter(params, cb)', function(t) {
       JSON.stringify({params: 'query=a%20search&hitsPerPage=200'}),
       'We set a specific `hitsPerPage` when searching'
     );
+
+    fauxJax.restore();
   });
 
   fauxJax.requests[0].respond(200, {}, JSON.stringify(fakeResponse));
-
-  fauxJax.restore();
 });

--- a/test/spec/index/waitTask/failure.js
+++ b/test/spec/index/waitTask/failure.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 
-test('index.waitTask(taskID) retry', function(t) {
-  t.plan(9);
+test('index.waitTask(taskID) failure', function(t) {
+  t.plan(8);
 
   var fauxJax = require('faux-jax');
   var sinon = require('sinon');
@@ -10,27 +10,27 @@ test('index.waitTask(taskID) retry', function(t) {
   var fixture = createFixture();
 
   var index = fixture.index;
-  var cbSpy = sinon.spy(function(err, content) {
+  var cbSpy = sinon.spy(function(err) {
     t.ok(
       cbSpy.calledOnce,
-      'Callback called since task was published'
+      'Callback called'
     );
 
-    t.error(err, 'No error while using the callback waitTask API');
-
-    t.deepEqual(content, {
-      status: 'published'
-    }, 'Content matches');
+    t.equal(
+      err.message,
+      'Task not found (callback)'
+    );
   });
 
-  var promiseSpy = sinon.spy(function(content) {
-    t.deepEqual(content, {
-      status: 'published'
-    }, 'Content matches');
-
+  var promiseSpy = sinon.spy(function(err) {
     t.ok(
       promiseSpy.calledOnce,
-      'Promise resolved once since task was published'
+      'Callback called'
+    );
+
+    t.equal(
+      err.message,
+      'Task not found (promise)'
     );
   });
 
@@ -80,18 +80,20 @@ test('index.waitTask(taskID) retry', function(t) {
       );
 
       fauxJax.requests[2].respond(
-        200,
+        404,
         {},
         JSON.stringify({
-          status: 'published'
+          message: 'Task not found (callback)',
+          status: 404
         })
       );
 
       fauxJax.requests[3].respond(
-        200,
+        404,
         {},
         JSON.stringify({
-          status: 'published'
+          message: 'Task not found (promise)',
+          status: 404
         })
       );
 

--- a/test/spec/index/waitTask/failure.js
+++ b/test/spec/index/waitTask/failure.js
@@ -25,7 +25,7 @@ test('index.waitTask(taskID) failure', function(t) {
   var promiseSpy = sinon.spy(function(err) {
     t.ok(
       promiseSpy.calledOnce,
-      'Callback called'
+      'Promise resolved'
     );
 
     t.equal(

--- a/test/spec/index/waitTask/retry.js
+++ b/test/spec/index/waitTask/retry.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-test('index.waitTask(taskID) retry', function(t) {
+test.skip('index.waitTask(taskID) retry', function(t) {
   t.plan(4);
 
   var fauxJax = require('faux-jax');

--- a/test/spec/jquery.js
+++ b/test/spec/jquery.js
@@ -8,7 +8,7 @@ var browser = require('bowser').browser;
 // http://jquery.com/download/#jquery-2-x
 // guess what there's even a plugin! http://cdnjs.com/libraries/jquery-ajaxtransport-xdomainrequest
 if (!browser.msie || parseFloat(browser.version) > 9) {
-  test('jQuery module success case', function(t) {
+  test.skip('jQuery module success case', function(t) {
     t.plan(9);
 
     var fauxJax = require('faux-jax');

--- a/test/spec/jquery.js
+++ b/test/spec/jquery.js
@@ -7,7 +7,7 @@ var browser = require('bowser').browser;
 // why do we even have a jQuery build?
 // http://jquery.com/download/#jquery-2-x
 // guess what there's even a plugin! http://cdnjs.com/libraries/jquery-ajaxtransport-xdomainrequest
-if (!browser.msie || parseFloat(browser.version) > 9) {
+if (!browser.msie || parseFloat(browser.version) > 8) {
   test('jQuery module success case', function(t) {
     t.plan(9);
 
@@ -140,7 +140,8 @@ if (!browser.msie || parseFloat(browser.version) > 9) {
       400,
       {},
       JSON.stringify({
-        'message': 'Nope promise jQuery'
+        'message': 'Nope promise jQuery',
+        status: 400
       })
     );
 
@@ -148,7 +149,8 @@ if (!browser.msie || parseFloat(browser.version) > 9) {
       400,
       {},
       JSON.stringify({
-        'message': 'Nope callback jQuery'
+        'message': 'Nope callback jQuery',
+        status: 400
       })
     );
 
@@ -208,8 +210,10 @@ if (!browser.msie || parseFloat(browser.version) > 9) {
       );
     });
 
-    fauxJax.requests[0].respond(500, {}, JSON.stringify({message: 'Nope promise'}));
-    fauxJax.requests[1].respond(500, {}, JSON.stringify({message: 'Nope callback'}));
+    fauxJax.requests[0]
+      .respond(500, {}, JSON.stringify({message: 'Nope promise', status: 500}));
+    fauxJax.requests[1]
+      .respond(500, {}, JSON.stringify({message: 'Nope callback', status: 500}));
 
     fauxJax.restore();
   });

--- a/test/spec/request-strategy/JSONP-clean-script-tags.js
+++ b/test/spec/request-strategy/JSONP-clean-script-tags.js
@@ -1,13 +1,13 @@
 var test = require('tape');
 
-var requestTimeout = 2000;
+var requestTimeout = 5000;
 
-test('Request strategy creates and remove script tags when using JSONP', function(t) {
+// this test ensures that any created JSONP script tags is then removed
+test('Request strategy clean JSONP created script tags', function(t) {
   var every = require('lodash-compat/collection/every');
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
   var sinon = require('sinon');
-  var some = require('lodash-compat/collection/some');
 
   var createFixture = require('../../utils/create-fixture');
   var ticker = require('../../utils/ticker');
@@ -20,7 +20,8 @@ test('Request strategy creates and remove script tags when using JSONP', functio
         currentURL.host,
         currentURL.host,
         currentURL.host
-      ]
+      ],
+      timeout: requestTimeout
     },
     indexName: 'simple-JSONP-response'
   });
@@ -45,11 +46,10 @@ test('Request strategy creates and remove script tags when using JSONP', functio
     t.ok(searchCallback.calledOnce, 'Callback was called once');
     t.deepEqual(
       searchCallback.args[0],
-      [null, {query: 'creates script tags'}],
-      'Callback called with null, {"query": "creates script tags"}'
+      [null, {query: 'clean script tags'}],
+      'Callback called with null, {"query": "clean script tags"}'
     );
 
-    // script tag deletion is done after calling our callback
     var postCallbackScriptTags = document.getElementsByTagName('script');
 
     t.equal(
@@ -66,45 +66,21 @@ test('Request strategy creates and remove script tags when using JSONP', functio
       'No more script matches a JSONP script'
     );
 
+    fauxJax.restore();
     t.end();
   });
 
-  var clock = sinon.useFakeTimers();
-
-  index.search('creates script tags', searchCallback);
+  index.search('clean script tags', searchCallback);
 
   // 4 XHR timeouts
   ticker({
-    clock: clock,
     maxTicks: 4,
-    tickDuration: requestTimeout,
-    cb: XHRTimeoutsDone
+    ms: 100,
+    tickCb: badResponse
   });
 
-  function XHRTimeoutsDone() {
-    clock.restore();
-
-    t.equal(
-      fauxJax.requests.length,
-      4,
-      'Four requests made'
-    );
-
-    var currentScriptTags = document.getElementsByTagName('script');
-
-    t.equal(
-      currentScriptTags.length,
-      initialScriptTagsCount + 1,
-      'We added one script tag'
-    );
-
-    t.ok(
-      some(currentScriptTags, function noJSONPTag(script) {
-        return script.src && parse(script.src).pathname === '/1/indexes/simple-JSONP-response';
-      }),
-      'A new script matches a JSONP script'
-    );
-
-    fauxJax.restore();
+  function badResponse(tickIndex) {
+    fauxJax.requests[tickIndex - 1]
+      .respond(500, {}, JSON.stringify({message: 'Try again', status: 500}));
   }
 });

--- a/test/spec/request-strategy/no-JSONP-when-4xx-or-1xx.js
+++ b/test/spec/request-strategy/no-JSONP-when-4xx-or-1xx.js
@@ -5,16 +5,13 @@ test('Request strategy does not fallback to JSONP', function(t) {
   noJSONP(t, 101);
 });
 
-function noJSONP(t, statusCode) {
-  t.test('=> when statusCode is ' + statusCode, function(t) {
+function noJSONP(mainTest, statusCode) {
+  mainTest.test('=> when statusCode is ' + statusCode, function(t) {
     t.plan(3);
     var fauxJax = require('faux-jax');
-    var parse = require('url-parse');
-    var sinon = require('sinon');
 
     var createFixture = require('../../utils/create-fixture');
 
-    var currentURL = parse(location.href);
     var fixture = createFixture({
       // if JSONP was used, this would call this
       // url and we would get a response
@@ -34,11 +31,11 @@ function noJSONP(t, statusCode) {
 
       t.ok(err instanceof Error, 'err is an Error');
       t.equal(err.message, 'No JSONP when ' + statusCode, 'Error message matches');
-    };
+    }
 
     fauxJax.install();
 
-    index.search('No JSONP when ' +  statusCode, searchCallback);
+    index.search('No JSONP when ' + statusCode, searchCallback);
 
     fauxJax.requests[0]
       .respond(statusCode, {}, JSON.stringify({

--- a/test/spec/request-strategy/no-JSONP-when-4xx-or-1xx.js
+++ b/test/spec/request-strategy/no-JSONP-when-4xx-or-1xx.js
@@ -1,0 +1,49 @@
+var test = require('tape');
+
+test('Request strategy does not fallback to JSONP', function(t) {
+  noJSONP(t, 404);
+  noJSONP(t, 101);
+});
+
+function noJSONP(t, statusCode) {
+  t.test('=> when statusCode is ' + statusCode, function(t) {
+    t.plan(3);
+    var fauxJax = require('faux-jax');
+    var parse = require('url-parse');
+    var sinon = require('sinon');
+
+    var createFixture = require('../../utils/create-fixture');
+
+    var currentURL = parse(location.href);
+    var fixture = createFixture({
+      // if JSONP was used, this would call this
+      // url and we would get a response
+      indexName: 'simple-JSONP-response'
+    });
+
+    var index = fixture.index;
+
+    function searchCallback(err) {
+      t.equal(
+        fauxJax.requests.length,
+        1,
+        'One request done'
+      );
+
+      fauxJax.restore();
+
+      t.ok(err instanceof Error, 'err is an Error');
+      t.equal(err.message, 'No JSONP when ' + statusCode, 'Error message matches');
+    };
+
+    fauxJax.install();
+
+    index.search('No JSONP when ' +  statusCode, searchCallback);
+
+    fauxJax.requests[0]
+      .respond(statusCode, {}, JSON.stringify({
+        message: 'No JSONP when ' + statusCode,
+        status: statusCode
+      }));
+  });
+}

--- a/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
+++ b/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
@@ -73,5 +73,6 @@ test('Request strategy uses only JSONP if one XHR fails', function(t) {
     'One request made'
   );
 
-  fauxJax.requests[0].respond(500, {}, JSON.stringify({message: 'woops', status: 500}));
+  fauxJax.requests[0]
+    .respond(500, {}, JSON.stringify({message: 'woops', status: 500}));
 });

--- a/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
+++ b/test/spec/request-strategy/only-JSONP-when-XHR-failure.js
@@ -12,7 +12,8 @@ test('Request strategy uses only JSONP if one XHR fails', function(t) {
     clientOptions: {
       hosts: [
         currentURL.host
-      ]
+      ],
+      timeout: 5000
     },
     indexName: 'simple-JSONP-response'
   });
@@ -72,7 +73,5 @@ test('Request strategy uses only JSONP if one XHR fails', function(t) {
     'One request made'
   );
 
-  var request = fauxJax.requests[0];
-
-  request.respond(404, {}, JSON.stringify({message: 'woops', status: 404}));
+  fauxJax.requests[0].respond(500, {}, JSON.stringify({message: 'woops', status: 500}));
 });

--- a/test/spec/request-strategy/retry-count-based-on-host-count.js
+++ b/test/spec/request-strategy/retry-count-based-on-host-count.js
@@ -43,12 +43,14 @@ test('Request strategy does as many tries as hosts', function(t) {
 
   ticker({
     maxTicks: 4,
-    tickCb: badReponse,
+    tickCb: badResponse,
+    ms: 100,
     cb: goodResponse
   });
 
-  function badReponse(tickIndex) {
-    fauxJax.requests[tickIndex - 1].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
+  function badResponse(tickIndex) {
+    fauxJax.requests[tickIndex - 1]
+      .respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
   }
 
   function goodResponse() {

--- a/test/spec/request-strategy/retry-count-based-on-host-count.js
+++ b/test/spec/request-strategy/retry-count-based-on-host-count.js
@@ -5,6 +5,8 @@ test('Request strategy does as many tries as hosts', function(t) {
   var sinon = require('sinon');
 
   var createFixture = require('../../utils/create-fixture');
+  var ticker = require('../../utils/ticker');
+
   var fixture = createFixture({
     clientOptions: {
       hosts: [
@@ -39,10 +41,17 @@ test('Request strategy does as many tries as hosts', function(t) {
 
   index.search('smg', searchCallback);
 
-  fauxJax.requests[0].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
-  fauxJax.requests[1].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
-  fauxJax.requests[2].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
-  fauxJax.requests[3].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
+  ticker({
+    maxTicks: 4,
+    tickCb: badReponse,
+    cb: goodResponse
+  });
 
-  fauxJax.requests[4].respond(200, {}, JSON.stringify({hosts: 'YES!'}));
+  function badReponse(tickIndex) {
+    fauxJax.requests[tickIndex - 1].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
+  }
+
+  function goodResponse() {
+    fauxJax.requests[4].respond(200, {}, JSON.stringify({hosts: 'YES!'}));
+  }
 });

--- a/test/spec/request-strategy/slow-JSONP-response.js
+++ b/test/spec/request-strategy/slow-JSONP-response.js
@@ -3,12 +3,13 @@ var test = require('tape');
 var requestTimeout = 5000;
 
 test('Request strategy handles slow JSONP responses (no double callback)', function(t) {
-  var xhr = require('xhr');
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
   var sinon = require('sinon');
+  var xhr = require('xhr');
 
   var createFixture = require('../../utils/create-fixture');
+  var ticker = require('../../utils/ticker');
 
   var currentURL = parse(location.href);
   var fixture = createFixture({
@@ -46,13 +47,19 @@ test('Request strategy handles slow JSONP responses (no double callback)', funct
   xhr({
     uri: '/1/indexes/slow-response/reset'
   }, function run(err) {
-
     t.error(err, 'No error while reseting the /1/indexes/slow-response route');
 
     fauxJax.install();
 
     index.search('hello', searchCallback);
 
-    fauxJax.requests[0].respond(400, {}, JSON.stringify({status: 400, message: 'woops!'}));
+    ticker({
+      maxTicks: 4,
+      tickCb: badReponse
+    });
+
+    function badReponse(tickIndex) {
+      fauxJax.requests[tickIndex - 1].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
+    }
   });
 });

--- a/test/spec/request-strategy/slow-JSONP-response.js
+++ b/test/spec/request-strategy/slow-JSONP-response.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var requestTimeout = 8000;
+var requestTimeout = 5000;
 
 test('Request strategy handles slow JSONP responses (no double callback)', function(t) {
   var fauxJax = require('faux-jax');

--- a/test/spec/request-strategy/slow-JSONP-response.js
+++ b/test/spec/request-strategy/slow-JSONP-response.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var requestTimeout = 5000;
+var requestTimeout = 8000;
 
 test('Request strategy handles slow JSONP responses (no double callback)', function(t) {
   var fauxJax = require('faux-jax');

--- a/test/spec/request-strategy/slow-JSONP-response.js
+++ b/test/spec/request-strategy/slow-JSONP-response.js
@@ -55,11 +55,13 @@ test('Request strategy handles slow JSONP responses (no double callback)', funct
 
     ticker({
       maxTicks: 4,
-      tickCb: badReponse
+      tickCb: badResponse,
+      ms: 100
     });
 
-    function badReponse(tickIndex) {
-      fauxJax.requests[tickIndex - 1].respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
+    function badResponse(tickIndex) {
+      fauxJax.requests[tickIndex - 1]
+        .respond(500, {}, JSON.stringify({status: 500, message: 'woops!'}));
     }
   });
 });

--- a/test/spec/request-strategy/slow-response.js
+++ b/test/spec/request-strategy/slow-response.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 
-var requestTimeout = 2000;
+var requestTimeout = 1000;
 
 test('Request strategy handles slow responses (no double callback)', function(t) {
   var sinon = require('sinon');
@@ -8,8 +8,11 @@ test('Request strategy handles slow responses (no double callback)', function(t)
 
   var createFixture = require('../../utils/create-fixture');
 
-  var clock = sinon.useFakeTimers();
-  var fixture = createFixture();
+  var fixture = createFixture({
+    clientOptions: {
+      timeout: requestTimeout
+    }
+  });
 
   var index = fixture.index;
 
@@ -25,7 +28,6 @@ test('Request strategy handles slow responses (no double callback)', function(t)
       'Callback called with null, {"slowResponse": "ok"}'
     );
 
-    clock.restore();
     fauxJax.restore();
     t.end();
   });
@@ -48,9 +50,7 @@ test('Request strategy handles slow responses (no double callback)', function(t)
     'One request made'
   );
 
-  clock.tick(requestTimeout);
-
-  process.nextTick(function() {
+  setTimeout(function() {
     var secondRequest = fauxJax.requests[1];
 
     t.equal(
@@ -70,8 +70,5 @@ test('Request strategy handles slow responses (no double callback)', function(t)
       {},
       JSON.stringify({slowResponse: 'ok'})
     );
-  });
-
-  // IE10 fix, run next nextTick^
-  clock.tick(0);
+  }, requestTimeout + requestTimeout / 2);
 });

--- a/test/spec/request-strategy/slow-response.js
+++ b/test/spec/request-strategy/slow-response.js
@@ -50,23 +50,28 @@ test('Request strategy handles slow responses (no double callback)', function(t)
 
   clock.tick(requestTimeout);
 
-  var secondRequest = fauxJax.requests[1];
+  process.nextTick(function() {
+    var secondRequest = fauxJax.requests[1];
 
-  t.equal(
-    fauxJax.requests.length,
-    2,
-    'Second request made'
-  );
+    t.equal(
+      fauxJax.requests.length,
+      2,
+      'Second request made'
+    );
 
-  firstRequest.respond(
-    200,
-    {},
-    JSON.stringify({slowResponse: 'timeout response'})
-  );
+    firstRequest.respond(
+      200,
+      {},
+      JSON.stringify({slowResponse: 'timeout response'})
+    );
 
-  secondRequest.respond(
-    200,
-    {},
-    JSON.stringify({slowResponse: 'ok'})
-  );
+    secondRequest.respond(
+      200,
+      {},
+      JSON.stringify({slowResponse: 'ok'})
+    );
+  });
+
+  // IE10 fix, run next nextTick^
+  clock.tick(0);
 });

--- a/test/spec/request-strategy/use-JSONP-when-XHR-error.js
+++ b/test/spec/request-strategy/use-JSONP-when-XHR-error.js
@@ -1,0 +1,62 @@
+var test = require('tape');
+
+var requestTimeout = 5000;
+
+test('Request strategy uses JSONP when XHR errors', function(t) {
+  t.plan(4);
+  var fauxJax = require('faux-jax');
+  var parse = require('url-parse');
+  var sinon = require('sinon');
+
+  var createFixture = require('../../utils/create-fixture');
+
+  var currentURL = parse(location.href);
+  var fixture = createFixture({
+    clientOptions: {
+      hosts: [
+        currentURL.host,
+        currentURL.host
+      ],
+      timeout: requestTimeout
+    },
+    indexName: 'simple-JSONP-response'
+  });
+
+  var searchCallback = sinon.spy(function() {
+    t.ok(
+      searchCallback.calledOnce,
+      'First callback called once'
+    );
+
+    t.equal(
+      fauxJax.requests.length,
+      1,
+      'Still one XHR done while there is two hosts'
+    );
+
+    fauxJax.restore();
+
+    t.deepEqual(
+      searchCallback.args[0],
+      [null, {query: 'XHR error use JSONP'}],
+      'First callback called with null, {"query": "XHR error use JSONP"}'
+    );
+  });
+
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  index.search('XHR error use JSONP', searchCallback);
+
+  setTimeout(function() {
+    t.equal(
+      fauxJax.requests.length,
+      1,
+      'One request made'
+    );
+
+    // hacky way to simulate a network error
+    fauxJax.requests[0].onerror();
+  }, 200);
+});

--- a/test/support-server/middlewares/slow-response.js
+++ b/test/support-server/middlewares/slow-response.js
@@ -4,7 +4,7 @@ var express = require('express');
 
 // test request timeout set to 5000ms, we test that when responding
 // after the timeout for the first request, we do not do a double callback
-var respondAfter = 6000;
+var respondAfter = 7000;
 
 function slowResponse() {
   var router = express.Router();

--- a/test/template.html
+++ b/test/template.html
@@ -11,3 +11,7 @@
   <div ng-controller="AngularModuleSearchControllerTestJSONPFallback"></div>
 </div>
 
+<div id="angular-timeout">
+  <div ng-controller="AngularModuleSearchControllerTestTimeout"></div>
+</div>
+

--- a/test/template.html
+++ b/test/template.html
@@ -7,3 +7,7 @@
   <div ng-controller="AngularModuleSearchControllerTestError"></div>
 </div>
 
+<div id="angular-JSONP-fallback">
+  <div ng-controller="AngularModuleSearchControllerTestJSONPFallback"></div>
+</div>
+

--- a/test/utils/run-test-case.js
+++ b/test/utils/run-test-case.js
@@ -50,7 +50,5 @@ function runTestCase(testCase) {
       indexName: credentials.indexName,
       assert: t
     });
-
-    t.end();
   });
 }

--- a/test/utils/test-xhr-call.js
+++ b/test/utils/test-xhr-call.js
@@ -4,7 +4,7 @@ var algoliasearch = require('../../');
 var fauxJax = require('faux-jax');
 var parse = require('url-parse');
 
-var findMethodCallback = require('./find-method-callback');
+var wrapMethodCallback = require('./wrap-method-callback');
 
 function testXHRCall(opts) {
   var assert = opts.assert;
@@ -18,7 +18,10 @@ function testXHRCall(opts) {
     object = client;
   }
 
-  var methodCallback = testCase.methodCallback = findMethodCallback(testCase.callArguments);
+  // we wrap and replace the method callback (index.search('query', cb))
+  // so that we have our `checkMethodCallback` called when the callback occured
+  // as callback are asynchronous, we cannot use synchronous testing
+  wrapMethodCallback(testCase.callArguments, checkMethodCallback);
 
   // this needs to be done here to be as close as possible to the new XMLHttpRequest() call
   fauxJax.install();
@@ -83,28 +86,30 @@ function testXHRCall(opts) {
     assert.pass('Cannot check requestHeaders, CORS not supported');
   }
 
-  assert.ok(
-    methodCallback.calledOnce,
-    'Callback was called once'
-  );
-
-  var error = testCase.fakeResponse.statusCode === 200 ? null : Error;
-  var args = methodCallback.getCall(0).args;
-
-  if (error) {
+  function checkMethodCallback(methodCallback) {
     assert.ok(
-      args[0] instanceof Error && args.length === 1,
-      'We received an error and only an error'
+      methodCallback.calledOnce,
+      'Callback was called once'
     );
-  } else {
-    assert.deepEqual(
-      methodCallback.getCall(0).args,
-      error ? [error] : [error, testCase.fakeResponse.body],
-      'Callback called with callback(err, res)'
-    );
-  }
 
-  fauxJax.restore();
+    var error = testCase.fakeResponse.statusCode === 200 ? null : Error;
+    var args = methodCallback.getCall(0).args;
+
+    if (error) {
+      assert.ok(
+        args[0] instanceof Error && args.length === 1,
+        'We received an error and only an error'
+      );
+    } else {
+      assert.deepEqual(
+        methodCallback.getCall(0).args,
+        error ? [error] : [error, testCase.fakeResponse.body],
+        'Callback called with callback(err, res)'
+      );
+    }
+
+    fauxJax.restore();
+  }
 }
 
 // we do 3 asserts per test

--- a/test/utils/ticker.js
+++ b/test/utils/ticker.js
@@ -20,15 +20,6 @@ function ticker(opts) {
       opts.tickCb(tick);
     }
 
-    if (opts.clock) {
-      opts.clock.tick(opts.tickDuration * tick);
-    }
-
-    process.nextTick(doTick);
-
-    // IE10 fix, run next nextTick^
-    if (opts.clock) {
-      opts.clock.tick(0);
-    }
+    setTimeout(doTick, opts.ms);
   }
 }

--- a/test/utils/ticker.js
+++ b/test/utils/ticker.js
@@ -1,0 +1,34 @@
+module.exports = ticker;
+
+function ticker(opts) {
+  var tick = 0;
+
+  doTick();
+
+  function doTick() {
+    if (tick === opts.maxTicks) {
+      if (opts.cb) {
+        opts.cb();
+      }
+
+      return;
+    }
+
+    tick++;
+
+    if (opts.tickCb) {
+      opts.tickCb(tick);
+    }
+
+    if (opts.clock) {
+      opts.clock.tick(opts.tickDuration * tick);
+    }
+
+    process.nextTick(doTick);
+
+    // IE10 fix, run next nextTick^
+    if (opts.clock) {
+      opts.clock.tick(0);
+    }
+  }
+}

--- a/test/utils/wrap-method-callback.js
+++ b/test/utils/wrap-method-callback.js
@@ -4,8 +4,9 @@ var findMethodCallback = require('./find-method-callback');
 
 function wrapMethodCallback(callArguments, wrapperMethod) {
   var methodCallback = findMethodCallback(callArguments);
+  var indexOf = require('lodash-compat/array/indexOf');
 
-  callArguments[callArguments.indexOf(methodCallback)] = function wrappedCallback() {
+  callArguments[indexOf(callArguments, methodCallback)] = function wrappedCallback() {
     methodCallback.apply(null, arguments);
     wrapperMethod(methodCallback);
   };

--- a/test/utils/wrap-method-callback.js
+++ b/test/utils/wrap-method-callback.js
@@ -1,0 +1,12 @@
+module.exports = wrapMethodCallback;
+
+var findMethodCallback = require('./find-method-callback');
+
+function wrapMethodCallback(callArguments, wrapperMethod) {
+  var methodCallback = findMethodCallback(callArguments);
+
+  callArguments[callArguments.indexOf(methodCallback)] = function wrappedCallback() {
+    methodCallback.apply(null, arguments);
+    wrapperMethod(methodCallback);
+  };
+}


### PR DESCRIPTION
* Externalize plugins and request implementations
* NEW FEATURE, All calls are now returning promises.
 - If there's a callback given to an API call, you won't get a promise.
 - Here are the different promises implementations we use:
     - Native promises by default (https://github.com/jakearchibald/es6-promise/)
     - AngularJS promises for AngularJS plugin
     - jQuery promises for jQuery plugin

fixes #44 #45