### PR TITLE
load algoliasearch V2 when jsDelivr `latest` detected

### DIFF
--- a/src/algoliasearch.angular.js
+++ b/src/algoliasearch.angular.js
@@ -86,3 +86,5 @@ global.angular.module('algoliasearch', [])
       }
     };
   }]);
+
+require('./migration-layer')('algoliasearch.angular');

--- a/src/algoliasearch.jquery.js
+++ b/src/algoliasearch.jquery.js
@@ -71,3 +71,5 @@ request.delay = function(ms) {
     }, ms);
   }).promise();
 };
+
+require('./migration-layer')('algoliasearch.jquery');

--- a/src/browser.js
+++ b/src/browser.js
@@ -138,20 +138,4 @@ request.delay = function(ms) {
   });
 };
 
-var migrationMessage = 'You are trying to use a new version of the AlgoliaSearch JavaScript client with an old notation.' +
-  ' Please read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
-
-// cannot dinamically add these properties to window, fails on IE old versions
-/*global AlgoliaSearch:true,AlgoliaSearchHelper:true,AlgoliaExplainResults:true*/
-/*eslint no-unused-vars: [2, {"vars": "local"}]*/
-AlgoliaSearch = function() {
-  throw new Error(migrationMessage);
-};
-
-AlgoliaSearchHelper = function() {
-  throw new Error(migrationMessage);
-};
-
-AlgoliaExplainResults = function() {
-  throw new Error(migrationMessage);
-};
+require('./migration-layer')('algoliasearch');

--- a/src/migration-layer/index.js
+++ b/src/migration-layer/index.js
@@ -1,0 +1,20 @@
+module.exports = migrationLayer;
+
+// Now onto the V2 related code:
+//  If the client is using /latest/$BUILDNAME.min.js, load V2 of the library
+//
+//  Otherwise, setup a migration layer that will throw on old constructors like
+//  new AlgoliaSearch().
+//  So that users upgrading from v2 to v3 will have a clear information
+//  message on what to do if they did not read the migration guide
+function migrationLayer(buildName) {
+  var isUsingLatest = require('./is-using-latest');
+  var loadV2 = require('./load-v2');
+  var oldGlobals = require('./old-globals');
+
+  if (isUsingLatest(buildName)) {
+    loadV2(buildName);
+  } else {
+    oldGlobals();
+  }
+}

--- a/src/migration-layer/is-using-latest.js
+++ b/src/migration-layer/is-using-latest.js
@@ -4,7 +4,7 @@
 module.exports = isUsingLatest;
 
 function isUsingLatest(buildName) {
-  var toFind = new RegExp('cdn.jsdelivr.net/algoliasearch/latest' +
+  var toFind = new RegExp('cdn\\.jsdelivr\\.net/algoliasearch/latest/' +
     buildName.replace('.', '\\.') + // algoliasearch, algoliasearch.angular
     '(?:\\.min)?\\.js$'); // [.min].js
 

--- a/src/migration-layer/is-using-latest.js
+++ b/src/migration-layer/is-using-latest.js
@@ -1,0 +1,23 @@
+// this module helps finding if the current page is using
+// the cdn.jsdelivr.net/algoliasearch/latest/$BUILDNAME.min.js version
+
+module.exports = isUsingLatest;
+
+function isUsingLatest(buildName) {
+  var toFind = new RegExp('cdn.jsdelivr.net/algoliasearch/latest' +
+    buildName.replace('.', '\\.') + // algoliasearch, algoliasearch.angular
+    '(?:\\.min)?\\.js$'); // [.min].js
+
+  var scripts = document.getElementsByTagName('script');
+  var found = false;
+  for (var currentScript = 0, nbScripts = scripts.length;
+        currentScript < nbScripts;
+        currentScript++) {
+    if (scripts[currentScript].src && toFind.test(scripts[currentScript].src)) {
+      found = true;
+      break;
+    }
+  }
+
+  return found;
+}

--- a/src/migration-layer/load-v2.js
+++ b/src/migration-layer/load-v2.js
@@ -1,0 +1,22 @@
+module.exports = loadV2;
+
+function loadV2(buildName) {
+  var message =
+    'Warning, you are using the `latest` version tag from jsDelivr for the AlgoliaSearch library.\n' +
+    'We updated the AlgoliaSearch JavaScript client to V3, using `latest` is no more recommended.\n' +
+    'Please read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
+
+  if (global.console) {
+    if (global.console.warn) {
+      global.console.warn(message);
+    } else if (global.console.log) {
+      global.console.log(message);
+    }
+  }
+
+  // why \x3c? http://stackoverflow.com/a/236106/147079
+  document.write(
+    '\x3Cscript src="//cdn.jsdelivr.net/algoliasearch/2.9/' +
+    buildName + '.min.js">\x3C/script>'
+  );
+}

--- a/src/migration-layer/old-globals.js
+++ b/src/migration-layer/old-globals.js
@@ -1,3 +1,6 @@
+/*global AlgoliaExplainResults:true*/
+/*eslint no-unused-vars: [2, {"vars": "local"}]*/
+
 module.exports = oldGlobals;
 
 function oldGlobals() {
@@ -5,17 +8,15 @@ function oldGlobals() {
     'You are trying to use a new version of the AlgoliaSearch JavaScript client with an old notation.' +
     '\nPlease read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
 
-  // cannot dynamically add these properties to window, fails on IE old versions
-  /*global AlgoliaSearch:true,AlgoliaSearchHelper:true,AlgoliaExplainResults:true*/
-  /*eslint no-unused-vars: [2, {"vars": "local"}]*/
-  AlgoliaSearch = function() {
+  global.AlgoliaSearch = function() {
     throw new Error(message);
   };
 
-  AlgoliaSearchHelper = function() {
+  global.AlgoliaSearchHelper = function() {
     throw new Error(message);
   };
 
+  // cannot use window.AlgoliaExplainResults on old IEs, dunno why
   AlgoliaExplainResults = function() {
     throw new Error(message);
   };

--- a/src/migration-layer/old-globals.js
+++ b/src/migration-layer/old-globals.js
@@ -1,0 +1,22 @@
+module.exports = oldGlobals;
+
+function oldGlobals() {
+  var message =
+    'You are trying to use a new version of the AlgoliaSearch JavaScript client with an old notation.' +
+    '\nPlease read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
+
+  // cannot dynamically add these properties to window, fails on IE old versions
+  /*global AlgoliaSearch:true,AlgoliaSearchHelper:true,AlgoliaExplainResults:true*/
+  /*eslint no-unused-vars: [2, {"vars": "local"}]*/
+  AlgoliaSearch = function() {
+    throw new Error(message);
+  };
+
+  AlgoliaSearchHelper = function() {
+    throw new Error(message);
+  };
+
+  AlgoliaExplainResults = function() {
+    throw new Error(message);
+  };
+}

--- a/test/spec/old-globals.js
+++ b/test/spec/old-globals.js
@@ -7,7 +7,7 @@
 var test = require('tape');
 
 var message = 'You are trying to use a new version of the AlgoliaSearch JavaScript client with an old notation.' +
-  ' Please read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
+  '\nPlease read our migration guide at https://github.com/algolia/algoliasearch-client-js/wiki/Migration-guide-from-2.x.x-to-3.x.x';
 
 test('new AlgoliaSearch() throws', function(t) {
   t.plan(3);


### PR DESCRIPTION
This will make the V3 update handle the `latest/algoliasearch.min.js`
usage.

fixes #63 

@redox @bobylito 

When manually upgrading to V3 without modifying usage:
![2015-03-23-151224_1056x46_scrot](https://cloud.githubusercontent.com/assets/123822/6781628/53e0ba08-d16f-11e4-9ef6-75f06edecace.png)

When using `latest` version tag from jsdelivr:
![2015-03-23-151209_1091x188_scrot](https://cloud.githubusercontent.com/assets/123822/6781638/63862b32-d16f-11e4-8976-00a3678b9601.png)

