### PR TITLE
Fix #73 : if protocol is not http or https, default to http

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 CHANGELOG
 
+UNRELEASED
+    * FIX: Defaults to http when the protocol of the page is not http or
+      https.
+
 2015-28-03  3.0.3
 
     * FIX: Handle module loaders + cdn.jsdelivr.net/algoliasearch/latest usage

--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -37,7 +37,8 @@ function AlgoliaSearch(applicationID, apiKey, opts, _request) {
   }
 
   if (opts.protocol === undefined) {
-    opts.protocol = document && document.location.protocol || 'http:';
+    var locationProtocol = document && document.location.protocol;
+    opts.protocol = (locationProtocol === 'http:' || locationProtocol === 'https:') ? locationProtocol : 'http:';
   }
 
   if (opts.hosts === undefined) {


### PR DESCRIPTION
Previous was using the wrong base #74 