### PR TITLE
server/builds/nodejs: try-catch end JSON response

### DIFF
--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -133,10 +133,19 @@ AlgoliaSearchNodeJS.prototype._request = function(rawUrl, opts) {
       }
 
       function end() {
-        resolve({
-          statusCode: res.statusCode,
-          body: JSON.parse(Buffer.concat(chunks))
-        });
+        var data = Buffer.concat(chunks);
+        var result = null;
+        try {
+          body = JSON.parse(data);
+          result = {
+            statusCode: res.statusCode,
+            body: body,
+          }
+        } catch (ex) {
+          result = new Error(data.toString());
+        } finally {
+          resolve(result);
+        }
       }
     }
 


### PR DESCRIPTION
This PR addresses issue #89 on receiving a malformed response that is un-JSON parseable.