### PR TITLE
feat: new browse()/browseFrom()/browseAll()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,25 @@ UNRELEASED
     * fix: do not use global when we know we will be in a browser
       browserify `global` is not always `window` can be <div id="global"></div>
       fixes #99
+    * feat: new browse()/browseFrom()/browseAll()
+      - `browse(query, queryParameters)` now has the same signature than
+      search(). You can use any `query` and `queryParameters`.
+      - `browseFrom(cursor)` can be used as an efficient way to
+      continue (next page) a previous `browse()` call. All browse responses now have a `cursor` property.
+      - `browseAll(query, queryParameters)` can be used to get all
+      the content of your index
+        It returns an [EventEmitter](https://nodejs.org/api/events.html).
+
+        Available events:
+          - `result`
+          - `end`
+          - `error` (you should listen to it or it will throw)
+
+        There's also `stop()` method on the event emitter so that you can
+        stop browsing at any point.
+
+      fixes #101
+
 
 2015-05-23 3.4.0
     * FIX: Remove debugging messages from builds

--- a/README.md
+++ b/README.md
@@ -1340,20 +1340,53 @@ client.moveIndex('MyNewIndex', 'MyIndex', function(err, content) {
 Backup / Retrieve of all index content
 -------------
 
-You can retrieve all index content for backup purposes or for SEO using the browse method.
-This method retrieves 1,000 objects via an API call and supports pagination.
+You can retrieve all index content by using the browseAll() method:
+```js
+// browseAll can take any query and queryParameter like the
+// search function. Here we do not provide any because we want all the index's
+// objects
+var browser = index.browseAll();
+var hits = [];
+
+browser.on('result', function onResult(content) {
+  hits = hits.concat(content.hits);
+});
+
+browser.on('end', function onEnd() {
+  console.log('Finished!');
+  console.log('We got %d hits', hits.length);
+});
+
+browser.on('error', function onError(err) {
+  throw err;
+});
+
+// You can stop the process at any point with
+// browser.stop();
+```
+
+You can also use the `browse(query, queryParameters)` and `browseFrom(browseCursor)` methods to programmatically browse your index content:
 
 ```js
-// Get first page
-index.browse(0, function(err, content) {
-  console.log(content);
-});
+index.browse('jazz', function browseDone(err, content) {
+  if (err) {
+    throw err;
+  }
 
-// Get second page
-index.browse(1, function(err, content) {
-  console.log(content);
+  console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
+
+  if (content.cursor) {
+    index.browseFrom(content.cursor, function browseFromDone(err, content) {
+      if (err) {
+        throw err;
+      }
+
+      console.log('We are at page %d on a total of %d pages, with %d hits.', content.page, content.nbPages, content.hits.length);
+    });
+  }
 });
 ```
+
 
 Logs
 -------------

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test-node-integration": "node test/run-integration.js",
     "test-browser-integration": "npm run build && DEBUG=zuul* zuul --no-coverage -- test/run-integration.js",
     "dev": "APP_ENV=development DEBUG=zuul* zuul --no-coverage --local 8080 -- test/run-browser.js",
+    "dev-integration": "APP_ENV=development DEBUG=zuul* zuul --no-coverage --local 8080 -- test/run-integration.js",
     "examples": "http-server . -a 0.0.0.0",
     "lint": "eslint --quiet test/"
   },
@@ -91,7 +92,7 @@
     "server-destroy": "1.0.0",
     "sinon": "1.12.2",
     "tape": "4.0.0",
-    "url-parse": "1.0.0",
+    "url-parse": "1.0.1",
     "webpack": "1.8.5",
     "xhr": "2.0.1",
     "zuul": "3.0.0",

--- a/src/IndexBrowser.js
+++ b/src/IndexBrowser.js
@@ -1,0 +1,37 @@
+// This is the object returned by the `index.browseAll()` method
+
+module.exports = IndexBrowser;
+
+var inherits = require('inherits');
+var EventEmitter = require('events').EventEmitter;
+
+function IndexBrowser() {}
+
+inherits(IndexBrowser, EventEmitter);
+
+IndexBrowser.prototype.stop = function() {
+  this._stopped = true;
+  this.emit('stop');
+  this._clean();
+};
+
+IndexBrowser.prototype._end = function() {
+  this.emit('end');
+  this._clean();
+};
+
+IndexBrowser.prototype._error = function(err) {
+  this.emit('error', err);
+  this._clean();
+};
+
+IndexBrowser.prototype._result = function(content) {
+  this.emit('result', content);
+};
+
+IndexBrowser.prototype._clean = function() {
+  this.removeAllListeners('stop');
+  this.removeAllListeners('end');
+  this.removeAllListeners('error');
+  this.removeAllListeners('result');
+};

--- a/src/browser/builds/algoliasearch.js
+++ b/src/browser/builds/algoliasearch.js
@@ -112,7 +112,8 @@ AlgoliaSearchBrowser.prototype._request = function(url, opts) {
       try {
         out = {
           body: JSON.parse(req.responseText),
-          statusCode: req.status
+          statusCode: req.status,
+          headers: req.getAllResponseHeaders()
         };
       } catch(e) {
         out = new errors.UnparsableJSON({more: req.responseText});

--- a/test/spec/common/index/browseAll/error-occurs.js
+++ b/test/spec/common/index/browseAll/error-occurs.js
@@ -1,0 +1,45 @@
+var test = require('tape');
+
+test('index.browseAll() and an error occurs', function(t) {
+  t.plan(2);
+
+  var fauxJax = require('faux-jax');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll('some', {
+    hitsPerPage: 200
+  });
+
+  fauxJax.once('request', browse);
+  browser.once('error', error);
+  browser.once('end', bind(t.fail, t));
+
+  function browse(req) {
+    req.respond(
+      400,
+      {},
+      JSON.stringify({
+        message: 'You are doomed'
+      })
+    );
+
+    fauxJax.restore();
+  }
+
+  function error(err) {
+    t.ok(err instanceof Error, 'We got an error');
+    t.equal(
+      err.message,
+      'You are doomed',
+      'error message matches'
+    );
+  }
+});
+
+

--- a/test/spec/common/index/browseAll/no-arguments.js
+++ b/test/spec/common/index/browseAll/no-arguments.js
@@ -1,0 +1,38 @@
+var test = require('tape');
+
+test.skip('index.browseAll() no arguments', function(t) {
+  t.plan(1);
+
+  var fauxJax = require('faux-jax');
+  var keys = require('lodash-compat/object/keys');
+  var parse = require('url-parse');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll();
+
+  fauxJax.once('request', browse);
+  browser.once('error', bind(t.fail, t));
+
+  function browse(req) {
+    var qs = parse(req.requestURL, true).query;
+    t.equal(3, keys(qs).length, 'We do not add any query parameter');
+
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 100
+      })
+    );
+
+    fauxJax.restore();
+  }
+});
+
+

--- a/test/spec/common/index/browseAll/only-query.js
+++ b/test/spec/common/index/browseAll/only-query.js
@@ -1,0 +1,45 @@
+var test = require('tape');
+
+test('index.browseAll(query)', function(t) {
+  t.plan(2);
+
+  var fauxJax = require('faux-jax');
+  var keys = require('lodash-compat/object/keys');
+  var parse = require('url-parse');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll('some');
+
+  fauxJax.once('request', browse);
+  browser.once('error', bind(t.fail, t));
+
+  function browse(req) {
+    var parsedURL = parse(req.requestURL, true);
+    var qs = parsedURL.query;
+
+    t.equal(qs.query, 'some', 'query param matches');
+    if (process.browser) {
+      t.equal(keys(qs).length, 4, 'We added only one parameter to the standard query string');
+    } else {
+      t.equal(keys(qs).length, 1, 'We added only one parameter to the standard query string');
+    }
+
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 100
+      })
+    );
+
+    fauxJax.restore();
+  }
+});
+
+

--- a/test/spec/common/index/browseAll/only-queryParameters.js
+++ b/test/spec/common/index/browseAll/only-queryParameters.js
@@ -1,0 +1,48 @@
+var test = require('tape');
+
+test('index.browseAll(queryParameters)', function(t) {
+  t.plan(2);
+
+  var fauxJax = require('faux-jax');
+  var keys = require('lodash-compat/object/keys');
+  var parse = require('url-parse');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll({
+    hitsPerPage: 1200
+  });
+
+  fauxJax.once('request', browse);
+  browser.once('error', bind(t.fail, t));
+
+  function browse(req) {
+    var parsedURL = parse(req.requestURL, true);
+    var qs = parsedURL.query;
+
+    t.equal(qs.hitsPerPage, '1200', 'query param matches');
+
+    if (process.browser) {
+      t.equal(keys(qs).length, 4, 'We added only one parameter to the standard query string');
+    } else {
+      t.equal(keys(qs).length, 1, 'We added only one parameter to the standard query string');
+    }
+
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 100
+      })
+    );
+
+    fauxJax.restore();
+  }
+});
+
+

--- a/test/spec/common/index/browseAll/standard.js
+++ b/test/spec/common/index/browseAll/standard.js
@@ -1,0 +1,78 @@
+var test = require('tape');
+
+test('index.browseAll(query, queryParameters)', function(t) {
+  t.plan(7);
+
+  var fauxJax = require('faux-jax');
+  var parse = require('url-parse');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll('some', {
+    hitsPerPage: 200
+  });
+
+  browser.once('result', firstResult);
+  fauxJax.once('request', firstBrowse);
+  browser.once('end', end);
+  browser.once('error', bind(t.fail, t));
+
+  function firstBrowse(req) {
+    var parsedURL = parse(req.requestURL, true);
+    var qs = parsedURL.query;
+
+    t.equal(
+      parsedURL.pathname,
+      '/1/indexes/' + encodeURIComponent(fixture.credentials.indexName) + '/browse',
+      'pathname matches'
+    );
+    t.equal(qs.query, 'some', 'query param matches');
+    t.equal(qs.hitsPerPage, '200', 'hitsPerPage param matches');
+
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 100,
+        cursor: 'fslajf21rf31fé==!'
+      })
+    );
+
+    fauxJax.once('request', secondBrowse);
+  }
+
+  function secondBrowse(req) {
+    var qs = parse(req.requestURL, true).query;
+    t.equal(qs.cursor, 'fslajf21rf31fé==!');
+
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 300
+      })
+    );
+
+    fauxJax.restore();
+  }
+
+  function firstResult(content) {
+    t.equal(content.nbHits, 100, 'first result matches');
+    browser.once('result', secondResult);
+  }
+
+  function secondResult(content) {
+    t.equal(content.nbHits, 300, 'second result matches');
+  }
+
+  function end() {
+    t.pass('we got an end event');
+  }
+});
+
+

--- a/test/spec/common/index/browseAll/using-stop.js
+++ b/test/spec/common/index/browseAll/using-stop.js
@@ -1,0 +1,42 @@
+var test = require('tape');
+
+test('browser = index.browseAll(); browser.stop()', function(t) {
+  t.plan(1);
+
+  var fauxJax = require('faux-jax');
+
+  var bind = require('lodash-compat/function/bind');
+  var createFixture = require('../../../../utils/create-fixture');
+  var fixture = createFixture();
+  var index = fixture.index;
+
+  fauxJax.install();
+
+  var browser = index.browseAll({
+    hitsPerPage: 1200
+  });
+
+  fauxJax.once('request', browse);
+  browser.on('result', function() {
+    // if we pass two times here then it will fail
+    t.pass('We received a result event');
+    browser.stop();
+  });
+  browser.once('end', bind(t.fail, t));
+  browser.once('error', bind(t.fail, t));
+
+  function browse(req) {
+    req.respond(
+      200,
+      {},
+      JSON.stringify({
+        nbHits: 100,
+        cursor: 'fslajf21rf31fé==!'
+      })
+    );
+
+    fauxJax.restore();
+  }
+});
+
+

--- a/test/spec/common/index/interface.js
+++ b/test/spec/common/index/interface.js
@@ -24,6 +24,8 @@ test('AlgoliaSearch index API spec', function(t) {
     'addUserKeyWithValidity',
     'updateUserKey',
     'browse',
+    'browseFrom',
+    'browseAll',
     'clearCache',
     'clearIndex',
     'deleteByQuery',

--- a/test/spec/common/index/search/no-attributes.js
+++ b/test/spec/common/index/search/no-attributes.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 
 // this test ensures we can call index.search() without any argument
-test('index.search()', function(t) {
+test('index.search() no arguments', function(t) {
   t.plan(1);
   var fauxJax = require('faux-jax');
 

--- a/test/spec/common/index/test-cases/browse.js
+++ b/test/spec/common/index/test-cases/browse.js
@@ -29,4 +29,69 @@ module.exports = [{
       }
     }
   }
+}, {
+  object: 'index',
+  methodName: 'browse',
+  testName: 'index.browse(cb)',
+  callArguments: [],
+  action: 'read',
+  expectedRequest: {
+    method: 'GET',
+    URL: {
+      pathname: '/1/indexes/%s/browse',
+      query: {
+        page: '0'
+      }
+    }
+  }
+}, {
+  object: 'index',
+  methodName: 'browse',
+  testName: 'index.browse(query)',
+  callArguments: ['hel""lo'],
+  action: 'read',
+  expectedRequest: {
+    method: 'GET',
+    URL: {
+      pathname: '/1/indexes/%s/browse',
+      query: {
+        query: 'hel""lo'
+      }
+    }
+  }
+}, {
+  object: 'index',
+  methodName: 'browse',
+  testName: 'index.browse(queryParameters)',
+  callArguments: [{
+    some: 'thing'
+  }],
+  action: 'read',
+  expectedRequest: {
+    method: 'GET',
+    URL: {
+      pathname: '/1/indexes/%s/browse',
+      query: {
+        some: 'thing'
+      }
+    }
+  }
+}, {
+  object: 'index',
+  methodName: 'browse',
+  testName: 'index.browse(query, queryParameters)',
+  callArguments: ['BOUHHHH!!', {
+    some: 'thing'
+  }],
+  action: 'read',
+  expectedRequest: {
+    method: 'GET',
+    URL: {
+      pathname: '/1/indexes/%s/browse',
+      query: {
+        query: 'BOUHHHH!!',
+        some: 'thing'
+      }
+    }
+  }
 }];

--- a/test/spec/common/index/test-cases/browseFrom.js
+++ b/test/spec/common/index/test-cases/browseFrom.js
@@ -1,0 +1,16 @@
+module.exports = [{
+  object: 'index',
+  methodName: 'browseFrom',
+  testName: 'index.browseFrom(cursor, cb)',
+  callArguments: ['dsafsaflsakfsalf'],
+  action: 'read',
+  expectedRequest: {
+    method: 'GET',
+    URL: {
+      pathname: '/1/indexes/%s/browse',
+      query: {
+        cursor: 'dsafsaflsakfsalf'
+      }
+    }
+  }
+}];

--- a/test/utils/get-fake-objects.js
+++ b/test/utils/get-fake-objects.js
@@ -6,8 +6,11 @@ var times = require('lodash-compat/utility/times');
 
 var chance = new Chance();
 
-function getFakeObjects(max) {
-  var nbHits = random(1, max || 10);
+function getFakeObjects(nbHits) {
+  if (nbHits === undefined) {
+    nbHits = 10;
+  }
+
   return times(nbHits, getOneHit);
 }
 


### PR DESCRIPTION
- `browse(query, queryParameters)` now has the same signature than
search(). You can use any `query` and `queryParameters`.
- `browseFrom(cursor)` can be used as an efficient way to
continue (next page) a previous `browse()` call. All browse responses now have a `cursor` property.
- `browseAll(query, queryParameters)` can be used to get all
the content of your index
  It returns an [EventEmitter](https://nodejs.org/api/events.html).

  Available events:
    - `result`
    - `end`
    - `error` (you should listen to it or it will throw)

  There's also `stop()` method on the event emitter so that you can
  stop browsing at any point.

fixes #101