### PR TITLE
fix: CORS simple request for all browser builds

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@ UNRELEASED
     * chore: use uglifyjs instead of closure compiler
     * feat: allow passing hosts as hosts.read, hosts.write
     * feat: allow passing Algolia Agent as an option
+    * fix: CORS simple request for all browser builds
+      fixes #111
 
 2015-06-03 3.5.0
     * fix: send a descriptive timeout error when it occurs

--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -63,12 +63,26 @@ window.angular.module('algoliasearch', [])
         reject(new errors.RequestTimeout());
       }, opts.timeout);
 
+      var requestHeaders = {
+        'accept': 'application/json'
+      };
+
+      if (body) {
+        if (opts.method === 'POST') {
+          // https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+          requestHeaders['content-type'] = 'application/x-www-form-urlencoded';
+        } else {
+          requestHeaders['content-type'] = 'application/json';
+        }
+      }
+
       $http({
         url: url,
         method: opts.method,
         data: body,
         cache: false,
-        timeout: timeoutPromise
+        timeout: timeoutPromise,
+        headers: requestHeaders
       }).then(function success(response) {
         resolve({
           statusCode: response.status,

--- a/src/browser/builds/algoliasearch.jquery.js
+++ b/src/browser/builds/algoliasearch.jquery.js
@@ -48,11 +48,25 @@ AlgoliaSearchJQuery.prototype._request = function(url, opts) {
 
     url = inlineHeaders(url, opts.headers);
 
+    var requestHeaders = {
+      'accept': 'application/json'
+    };
+
+    if (body) {
+      if (opts.method === 'POST') {
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+        requestHeaders['content-type'] = 'application/x-www-form-urlencoded';
+      } else {
+        requestHeaders['content-type'] = 'application/json';
+      }
+    }
+
     $.ajax(url, {
       type: opts.method,
       timeout: opts.timeout,
       dataType: 'json',
       data: body,
+      headers: requestHeaders,
       complete: function(jqXHR, textStatus/* , error*/) {
         if (textStatus === 'timeout') {
           deferred.reject(new errors.RequestTimeout());

--- a/src/browser/builds/algoliasearch.js
+++ b/src/browser/builds/algoliasearch.js
@@ -68,8 +68,16 @@ AlgoliaSearchBrowser.prototype._request = function(url, opts) {
       req.open(opts.method, url);
     }
 
-    if (support.cors && body && opts.method !== 'GET') {
-      req.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
+    if (support.cors) {
+      if (body) {
+        if (opts.method === 'POST') {
+          // https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+          req.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
+        } else {
+          req.setRequestHeader('content-type', 'application/json');
+        }
+      }
+      req.setRequestHeader('accept', 'application/json');
     }
 
     // we set an empty onprogress listener

--- a/test/spec/browser/angular.js
+++ b/test/spec/browser/angular.js
@@ -6,7 +6,7 @@ var browser = require('bowser').browser;
 // https://docs.angularjs.org/guide/ie
 if (!browser.msie || parseFloat(browser.version) > 8) {
   test('AngularJS module success case', function(t) {
-    t.plan(9);
+    t.plan(10);
 
     var fauxJax = require('faux-jax');
     var parse = require('url-parse');
@@ -47,6 +47,14 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
           var firstRequest = requests[0];
           var secondRequest = requests[1];
           var requestURL = parse(firstRequest.requestURL, true);
+
+          t.deepEqual(
+            firstRequest.requestHeaders, {
+              'content-type': 'application/x-www-form-urlencoded',
+              'accept': 'application/json'
+            },
+            'requestHeaders matches'
+          );
 
           t.equal(
             requestURL.host,

--- a/test/spec/browser/jquery.js
+++ b/test/spec/browser/jquery.js
@@ -9,7 +9,7 @@ var browser = require('bowser').browser;
 // guess what there's even a plugin! http://cdnjs.com/libraries/jquery-ajaxtransport-xdomainrequest
 if (!browser.msie || parseFloat(browser.version) > 8) {
   test('jQuery module success case', function(t) {
-    t.plan(9);
+    t.plan(10);
 
     var fauxJax = require('faux-jax');
     var parse = require('url-parse');
@@ -48,6 +48,14 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
       var firstRequest = requests[0];
       var secondRequest = requests[1];
       var requestURL = parse(firstRequest.requestURL, true);
+
+      t.deepEqual(
+        firstRequest.requestHeaders, {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json'
+        },
+        'requestHeaders matches'
+      );
 
       t.equal(
         requestURL.host,

--- a/test/utils/compute-expected-request.js
+++ b/test/utils/compute-expected-request.js
@@ -27,8 +27,11 @@ function computeExpectedRequest(expectedRequest, credentials) {
     expectedRequest.body = null;
   }
 
-  if (expectedRequest.body !== null && expectedRequest.method === 'POST' || expectedRequest.method === 'PUT') {
-    if (process.browser) {
+  expectedRequest.headers.accept = 'application/json';
+
+  if (expectedRequest.body !== null) {
+    // CORS simple request
+    if (process.browser && expectedRequest.method === 'POST') {
       expectedRequest.headers['content-type'] = 'application/x-www-form-urlencoded';
     } else {
       expectedRequest.headers['content-type'] = 'application/json';
@@ -39,7 +42,6 @@ function computeExpectedRequest(expectedRequest, credentials) {
     expectedRequest.headers['x-algolia-api-key'] = credentials.searchOnlyAPIKey;
     expectedRequest.headers['x-algolia-application-id'] = credentials.applicationID;
     expectedRequest.headers['x-algolia-agent'] = algoliasearch.ua;
-    expectedRequest.headers.accept = 'application/json';
   }
 
   return expectedRequest;


### PR DESCRIPTION
We were not setting the right headers previously
    
Now setting
  - accept: application/json and
  - content-type: 'application/x-www-form-urlencoded' (POST)
  - content-type: 'application/json' (PUT)
    
fixes #111