### PR TITLE
fix: withCredentials forced to false in Angular

### DIFF
--- a/src/browser/builds/algoliasearch.angular.js
+++ b/src/browser/builds/algoliasearch.angular.js
@@ -90,7 +90,10 @@ window.angular.module('algoliasearch', [])
         data: body,
         cache: false,
         timeout: timeoutPromise,
-        headers: requestHeaders
+        headers: requestHeaders,
+        // if client uses $httpProvider.defaults.withCredentials = true,
+        // we revert it to false to avoid CORS failure
+        withCredentials: false
       }).then(function success(response) {
         resolve({
           statusCode: response.status,

--- a/test/spec/browser/angular.js
+++ b/test/spec/browser/angular.js
@@ -271,4 +271,41 @@ if (!browser.msie || parseFloat(browser.version) > 8) {
       window.angular.bootstrap(window.angular.element('#angular-timeout'), ['angularTimeout']);
     });
   });
+
+  test('AngularJS module withCredentials', function(t) {
+    var fauxJax = require('faux-jax');
+    t.plan(1);
+
+    // load AngularJS Algolia Search module
+    require('../../../src/browser/builds/algoliasearch.angular');
+
+    window.angular
+      .module('angularWithCredentials', ['algoliasearch'])
+      .config(['$httpProvider', function($httpProvider) {
+        $httpProvider.defaults.withCredentials = true;
+      }])
+      .controller('AngularModuleSearchControllerTestWithCredentials', ['algolia', function(algolia) {
+        var client = algolia.Client('AngularJSSuccess', 'ROCKSSuccess');
+        var index = client.initIndex('googleSuccess');
+        fauxJax.install();
+
+        index.search();
+
+        fauxJax.once('request', function(request) {
+          t.equal(
+            request.withCredentials,
+            false,
+            'withCredentials if false even if $http set it to true'
+          );
+
+          request.respond(200, {}, '');
+
+          fauxJax.restore();
+        });
+      }]);
+
+    window.angular.element(document).ready(function() {
+      window.angular.bootstrap(window.angular.element('#angular-with-credentials'), ['angularWithCredentials']);
+    });
+  });
 }

--- a/test/template.html
+++ b/test/template.html
@@ -15,3 +15,6 @@
   <div ng-controller="AngularModuleSearchControllerTestTimeout"></div>
 </div>
 
+<div id="angular-with-credentials">
+  <div ng-controller="AngularModuleSearchControllerTestWithCredentials"></div>
+</div>


### PR DESCRIPTION
This forces the Angular calls made to our API with `withCredentials` set to false (even if the user set them to true on their side, like when behind a Basic Auth)