### PR TITLE
Possible issue with local cache

### DIFF
--- a/src/AlgoliaSearch.js
+++ b/src/AlgoliaSearch.js
@@ -784,7 +784,7 @@ AlgoliaSearch.prototype = {
         var retry = !ok && Math.floor(status / 100) !== 4 && Math.floor(status / 100) !== 1;
 
         if (client._useCache && ok && cache) {
-          cache[cacheID] = httpResponse.responseText;
+          cache[cacheID] = httpResponse.body;
         }
 
         if (ok) {


### PR DESCRIPTION
We found that the local storage cache only works with `cache[cacheID] = httpResponse.body;`. Is there a reason for it to be `httpResponse.responseText`? We found that to always be null, at least in our case...