### PR TITLE
Fix #251: increments hostIndex (host adress) on fallback

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -360,19 +360,20 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         return client._promise.reject(err);
       }
 
-      if (err instanceof errors.RequestTimeout) {
+      if (err instanceof errors.RequestTimeout || err instanceof errors.NodeNetwork) {
         return retryRequest();
       } else if (!usingFallback) {
-        client.hostIndex[initialOpts.hostType] = ++client.hostIndex[initialOpts.hostType] % client.hosts[initialOpts.hostType].length;
         // next request loop, force using fallback for this request
         tries = Infinity;
       }
+
+      client.hostIndex[initialOpts.hostType] = (client.hostIndex[initialOpts.hostType] + 1) % client.hosts[initialOpts.hostType].length;
 
       return doRequest(requester, reqOpts);
     }
 
     function retryRequest() {
-      client.hostIndex[initialOpts.hostType] = ++client.hostIndex[initialOpts.hostType] % client.hosts[initialOpts.hostType].length;
+      client.hostIndex[initialOpts.hostType] = (client.hostIndex[initialOpts.hostType] + 1) % client.hosts[initialOpts.hostType].length;
       reqOpts.timeout = client.requestTimeout * (tries + 1);
       return doRequest(requester, reqOpts);
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -63,6 +63,10 @@ module.exports = {
     'Network',
     'Network issue, see err.more for details'
   ),
+  NodeNetwork: createCustomError(
+    'Network',
+    'Network issue, in the node context'
+  ),
   JSONPScriptFail: createCustomError(
     'JSONPScriptFail',
     '<script> was loaded but did not call our provided callback'

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -210,7 +210,7 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
 
       abort();
       clearTimeout(timeoutId);
-      reject(new errors.Network(err.message, err));
+      reject(new errors.NodeNetwork(err.message, err));
     }
 
     function timeout() {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -43,6 +43,9 @@ var objects = getFakeObjects(50);
 // avoid having to type index.waitTask.bind(index)
 _.bindAll(index);
 
+test('fallback strategy sucess', testFallbackStrategyDNSTimeout);
+test('fallback strategy all servers fail', testFallbackStrategyDNSTimeoutFail);
+
 test('index.clearIndex', clearIndex);
 test('index.saveObjects', saveObjects);
 test('index.browse', browse);
@@ -303,5 +306,48 @@ function waitKey(key, callback, tries) {
   tmpIndex.search(function(err) {
     if (err) return setTimeout(waitKey, 200, key, callback, tries++);
     callback(key);
+  });
+}
+
+function testFallbackStrategyDNSTimeout(t) {
+  var client_ = algoliasearch(
+    appId,
+    apiKey, {
+      hosts: ['latency-dsn.algolia.biz', 'latency-3.algolia.biz', 'latency-dsn.algolia.net']
+    }
+  );
+
+  t.ok(client_.hostIndex.read === 0, 'At the init of the client, the host index should be at 0');
+
+  var index_ = client_.initIndex('bestbuy');
+
+  index_.search('iphone').then(function(content) {
+    t.ok(content.hits.length > 0, 'hits should not be empty');
+    t.ok(client_.hostIndex.read === 2, 'At the end of the test, the host index should be at 2');
+    t.end();
+  }, function() {
+    t.fail('No error should be generated as it should lastly route to a good domain.');
+    t.end();
+  });
+}
+
+function testFallbackStrategyDNSTimeoutFail(t) {
+  var client_ = algoliasearch(
+    appId,
+    apiKey, {
+      hosts: ['latency-dsn.algolia.biz', 'latency-3.algolia.biz', 'latency-2.algolia.biz']
+    }
+  );
+
+  t.ok(client_.hostIndex.read === 0, 'At the init of the client, the host index should be at 0');
+
+  var index_ = client_.initIndex('bestbuy');
+
+  index_.search('iphone').then(function() {
+    t.fail('Should fail as no host are reachable');
+    t.end();
+  }, function() {
+    t.equal(client_.hostIndex.read, 2, 'At the end of the test, the host index should be at 2');
+    t.end();
   });
 }


### PR DESCRIPTION
NB: See #254 for previous discussions

This issue was caused because we do not distinguish CORS errors from DNS
resolution one and the code for incrementing the host index was moved into
the part that switches to the fallback.

Truth is that the current solution is not optimal as we are switching to
JSONP when we can't resolve the server name.