### PR TITLE
fix(retry): also retry on non search methods when DNS failure

### DIFF
--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -273,16 +273,8 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
       requestDebug('received response: statusCode: %s, computed statusCode: %d, headers: %j',
         httpResponse.statusCode, status, httpResponse.headers);
 
-      var ok = status === 200 || status === 201;
-      var retry = !ok && Math.floor(status / 100) !== 4 && Math.floor(status / 100) !== 1;
-
-      if (client._useCache && ok && cache) {
-        cache[cacheID] = httpResponse.responseText;
-      }
-
-      if (ok) {
-        return httpResponse.body;
-      }
+      var httpResponseOk = Math.floor(status / 100) === 2;
+      var shouldRetry = Math.floor(status / 100) !== 4 && Math.floor(status / 100) !== 2;
 
       var endTime = new Date();
       debugData.push({
@@ -298,11 +290,22 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         duration: endTime - startTime
       });
 
-      if (retry) {
+      if (httpResponseOk) {
+        if (client._useCache && cache) {
+          cache[cacheID] = httpResponse.responseText;
+        }
+
+        return httpResponse.body;
+      }
+
+      if (shouldRetry) {
         tries += 1;
         return retryRequest();
       }
 
+      requestDebug('unrecoverable error');
+
+      // no success and no retry => fail
       var unrecoverableError = new errors.AlgoliaSearchError(
         httpResponse.body && httpResponse.body.message, {debugData: debugData}
       );
@@ -360,27 +363,22 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         return client._promise.reject(err);
       }
 
-      // When a timeout occured or if a network error occured and we have no fallback
-      if (err instanceof errors.RequestTimeout || !hasFallback) {
-        return retryRequest();
+      // When a timeout occured, retry by raising timeout
+      if (err instanceof errors.RequestTimeout) {
+        return retryRequestWithHigherTimeout();
       }
 
-      // The only case where we reach here is a Network error occured, there's a fallback (JSONP), we use it
-      // we cannot easily distinguish blocked XHRS from DNS request failure in a cross browser way.
-      // So we use the fallback as soon as it's available and there was a network error, be it DNS failure or
-      // blocked XHR.
-
-      if (!usingFallback) {
-        // next request loop, force using fallback for this request
-        tries = Infinity;
-      }
-
-      client.hostIndex[initialOpts.hostType] = (client.hostIndex[initialOpts.hostType] + 1) % client.hosts[initialOpts.hostType].length;
-
-      return doRequest(requester, reqOpts);
+      return retryRequest();
     }
 
     function retryRequest() {
+      requestDebug('retrying request');
+      client.hostIndex[initialOpts.hostType] = (client.hostIndex[initialOpts.hostType] + 1) % client.hosts[initialOpts.hostType].length;
+      return doRequest(requester, reqOpts);
+    }
+
+    function retryRequestWithHigherTimeout() {
+      requestDebug('retrying request with higher timeout');
       client.hostIndex[initialOpts.hostType] = (client.hostIndex[initialOpts.hostType] + 1) % client.hosts[initialOpts.hostType].length;
       reqOpts.timeout = client.requestTimeout * (tries + 1);
       return doRequest(requester, reqOpts);

--- a/src/AlgoliaSearchCore.js
+++ b/src/AlgoliaSearchCore.js
@@ -360,9 +360,17 @@ AlgoliaSearchCore.prototype._jsonRequest = function(initialOpts) {
         return client._promise.reject(err);
       }
 
-      if (err instanceof errors.RequestTimeout || err instanceof errors.NodeNetwork) {
+      // When a timeout occured or if a network error occured and we have no fallback
+      if (err instanceof errors.RequestTimeout || !hasFallback) {
         return retryRequest();
-      } else if (!usingFallback) {
+      }
+
+      // The only case where we reach here is a Network error occured, there's a fallback (JSONP), we use it
+      // we cannot easily distinguish blocked XHRS from DNS request failure in a cross browser way.
+      // So we use the fallback as soon as it's available and there was a network error, be it DNS failure or
+      // blocked XHR.
+
+      if (!usingFallback) {
         // next request loop, force using fallback for this request
         tries = Infinity;
       }

--- a/src/errors.js
+++ b/src/errors.js
@@ -63,10 +63,6 @@ module.exports = {
     'Network',
     'Network issue, see err.more for details'
   ),
-  NodeNetwork: createCustomError(
-    'Network',
-    'Network issue, in the node context'
-  ),
   JSONPScriptFail: createCustomError(
     'JSONPScriptFail',
     '<script> was loaded but did not call our provided callback'

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -210,7 +210,7 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
 
       abort();
       clearTimeout(timeoutId);
-      reject(new errors.NodeNetwork(err.message, err));
+      reject(new errors.Network(err.message, err));
     }
 
     function timeout() {

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -14,6 +14,7 @@ var getFakeObjects = require('./utils/get-fake-objects');
 var isABrowser = process.browser;
 var canPUT = !isABrowser || require('faux-jax').support.xhr.cors;
 var canDELETE = canPUT;
+var FORCE_DNS_TIMEOUT = 120000;
 
 // ensure that on the browser we use the global algoliasearch,
 // so that we are absolutely sure the builded version exposes algoliasearch
@@ -318,7 +319,7 @@ function dnsFailThenSuccess(t) {
     apiKey, {
       // .biz is a black hole DNS name (not resolving)
       hosts: [appId + '-dsn.algolia.biz', appId + '-dsn.algolia.net'],
-      timeout: 120000 // let's wait for the DNS timeout
+      timeout: FORCE_DNS_TIMEOUT // let's wait for the DNS timeout
     }
   );
 
@@ -339,7 +340,7 @@ function dnsFailThenSuccessNoSearch(t) {
     apiKey, {
       // .biz is a black hole DNS name (not resolving)
       hosts: [appId + '-dsn.algolia.biz', appId + '-dsn.algolia.net'],
-      timeout: 120000, // let's wait for the DNS timeout
+      timeout: FORCE_DNS_TIMEOUT, // let's wait for the DNS timeout
       protocol: 'https:'
     }
   );
@@ -357,7 +358,7 @@ function dnsFailed(t) {
     appId,
     apiKey, {
       hosts: [appId + '-dsn.algolia.biz', appId + '-3.algolia.biz'],
-      timeout: 120000 // let's wait for the DNS timeout
+      timeout: FORCE_DNS_TIMEOUT // let's wait for the DNS timeout
     }
   );
 

--- a/test/run-integration.js
+++ b/test/run-integration.js
@@ -59,7 +59,8 @@ if (canPUT) {
   test('index.saveObject', saveObject);
 }
 
-test('fallback strategy sucess', dnsFailThenSuccess);
+test('fallback strategy success', dnsFailThenSuccess);
+test('fallback strategy success, not a search method', dnsFailThenSuccessNoSearch);
 test('fallback strategy all servers fail', dnsFailed);
 
 if (!process.browser) {
@@ -317,7 +318,7 @@ function dnsFailThenSuccess(t) {
     apiKey, {
       // .biz is a black hole DNS name (not resolving)
       hosts: [appId + '-dsn.algolia.biz', appId + '-dsn.algolia.net'],
-      timeout: 40000 // let's wait for the DNS timeout
+      timeout: 120000 // let's wait for the DNS timeout
     }
   );
 
@@ -330,13 +331,33 @@ function dnsFailThenSuccess(t) {
   });
 }
 
+function dnsFailThenSuccessNoSearch(t) {
+  t.plan(1);
+
+  var client_ = algoliasearch(
+    appId,
+    apiKey, {
+      // .biz is a black hole DNS name (not resolving)
+      hosts: [appId + '-dsn.algolia.biz', appId + '-dsn.algolia.net'],
+      timeout: 120000, // let's wait for the DNS timeout
+      protocol: 'https:'
+    }
+  );
+
+  client_.listIndexes().then(function(content) {
+    t.ok(content.items.length > 0, 'we found a list of indices');
+  }, function() {
+    t.fail('No error should be generated as it should lastly route to a good domain.');
+  });
+}
+
 function dnsFailed(t) {
   t.plan(1);
   var client_ = algoliasearch(
     appId,
     apiKey, {
       hosts: [appId + '-dsn.algolia.biz', appId + '-3.algolia.biz'],
-      timeout: 40000 // let's wait for the DNS timeout
+      timeout: 120000 // let's wait for the DNS timeout
     }
   );
 

--- a/test/spec/browser/request-strategy/JSONP-fallback-per-request.js
+++ b/test/spec/browser/request-strategy/JSONP-fallback-per-request.js
@@ -5,7 +5,7 @@ var test = require('tape');
 var requestTimeout = 5000;
 
 test('Request strategy uses JSONP fallback on a per requests basis', function(t) {
-  t.plan(3);
+  t.plan(6);
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
   var sinon = require('sinon');
@@ -47,9 +47,6 @@ test('Request strategy uses JSONP fallback on a per requests basis', function(t)
       'JSONP callback called with null, {"query": "XHR error use JSONP"}'
     );
 
-    fauxJax.once('request', function(req) {
-      req.respond(200, {}, JSON.stringify({HEY: 'XHR RESPONSE BABY!'}));
-    });
     index.search('Youpi', XHRCallback);
   });
 
@@ -57,8 +54,15 @@ test('Request strategy uses JSONP fallback on a per requests basis', function(t)
 
   index.search('XHR error use JSONP', JSONPCallback);
 
-  fauxJax.once('request', function(req) {
-    // hacky way to simulate a network error
-    req.onerror();
+  var reqCount = 0;
+  fauxJax.on('request', function(req) {
+    t.pass();
+    reqCount++;
+    if (reqCount === 3) {
+      req.respond(200, {}, JSON.stringify({HEY: 'XHR RESPONSE BABY!'}));
+    } else {
+      // hacky way to simulate a network error
+      req.onerror();
+    }
   });
 });

--- a/test/spec/browser/request-strategy/handles-JSONP-syntax-error.js
+++ b/test/spec/browser/request-strategy/handles-JSONP-syntax-error.js
@@ -11,7 +11,7 @@ if (browser.name === 'PhantomJS') {
 }
 
 test('Request strategy handles JSONP syntax errors', function(t) {
-  t.plan(6);
+  t.plan(8);
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
   var xhr = require('xhr');
@@ -56,8 +56,10 @@ test('Request strategy handles JSONP syntax errors', function(t) {
 
     index.search('JSONP Failure', searchCallback);
 
-    fauxJax.once('request', function(req) {
-      // hacky way to simulate a network error so that we try JSONP right away
+    fauxJax.on('request', function(req) {
+      // we should pass here as much time as the number of hosts (2)
+      t.pass();
+      // simulate network error
       req.onerror();
     });
   });

--- a/test/spec/browser/request-strategy/no-JSONP-when-4xx.js
+++ b/test/spec/browser/request-strategy/no-JSONP-when-4xx.js
@@ -4,7 +4,6 @@ var test = require('tape');
 
 test('Request strategy does not fallback to JSONP', function(t) {
   noJSONP(t, 404);
-  noJSONP(t, 101);
 });
 
 function noJSONP(mainTest, statusCode) {

--- a/test/spec/browser/request-strategy/use-JSONP-when-XHR-error.js
+++ b/test/spec/browser/request-strategy/use-JSONP-when-XHR-error.js
@@ -5,7 +5,7 @@ var test = require('tape');
 var requestTimeout = 5000;
 
 test('Request strategy uses JSONP when XHR errors', function(t) {
-  t.plan(2);
+  t.plan(4);
   var fauxJax = require('faux-jax');
   var parse = require('url-parse');
   var sinon = require('sinon');
@@ -45,8 +45,10 @@ test('Request strategy uses JSONP when XHR errors', function(t) {
 
   index.search('XHR error use JSONP', searchCallback);
 
-  fauxJax.once('request', function(req) {
-    // hacky way to simulate a network error
+  fauxJax.on('request', function(req) {
+    // we should pass here as much time as the number of hosts (2)
+    t.pass();
+    // simulate network error
     req.onerror();
   });
 });


### PR DESCRIPTION
Before this commit, methods with no fallback support (basically every
method but search) would fail at retry if the DNS error occured before the API
client timeout.

The behavior is now:
- when a method with a fallback errors because of DNS failure we will
switch to JSONP right away
- when a method with no fallback errors because of DNS failure we will
still retry

We could use the same mechanism for both (= always try all hosts
before JSONP) but I am not confident doing this change within a patch
or minor version. We have too litle data on how blocked XHRS are
triggered (async, sync?).

fixes #250