### PR TITLE
fix(retry strategy): Shared appId host usage, retry on first host after 1 minute

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-config-algolia": "4.2.0",
     "eslint-plugin-react": "^3.6.3",
     "express": "^4.13.4",
-    "faux-jax": "^5.0.4",
+    "faux-jax": "^5.0.6",
     "http-proxy": "^1.13.3",
     "http-server": "^0.9.0",
     "jquery": "^3.0.0",

--- a/scripts/test-node
+++ b/scripts/test-node
@@ -13,20 +13,17 @@ set -e # exit when error
 [ -z $TRAVIS_PULL_REQUEST ] && TRAVIS_PULL_REQUEST='false'
 [ -z $TRAVIS_BUILD_NUMBER ] && TRAVIS_BUILD_NUMBER='false'
 
-nvm install 6
+nvm install 7
 node test/run-node.js
 
 # in CI we launch integration test
-[ $CI == 'true' ] && echo "Node test 4: integration" && node test/run-integration.js
+[ $CI == 'true' ] && echo "Node test 7: integration" && node test/run-integration.js
 
 # in a PR or in local environement, test only on node 6
 if [ $TRAVIS_PULL_REQUEST != 'false' ] || [ $CI == 'false' ]; then
   echo 'Skipping other nodejs version testing (PR or local)'
   exit 0
 else
-  echo "Node test 6: integration"
-  node test/run-integration.js
-
   echo "Node test 0.10: integration"
   nvm install 0.10
   node test/run-integration.js
@@ -42,7 +39,11 @@ else
   echo "Node test 5: integration"
   nvm install 5
   node test/run-integration.js
+
+  echo "Node test 6: integration"
+  nvm install 6
+  node test/run-integration.js
 fi
 
 # switch back to node.js 6
-nvm use 6
+nvm use 7

--- a/src/server/builds/node.js
+++ b/src/server/builds/node.js
@@ -158,11 +158,16 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
     function response(res) {
       var chunks = [];
 
+      // save headers and statusCode BEFORE treating the response as zlib, otherwise
+      // we lose them
+      var headers = res.headers;
+      var statusCode = res.statusCode;
+
       // Algolia answers should be gzip when asked for it,
       // but a proxy might uncompress Algolia response
       // So we handle both compressed and uncompressed
-      if (res.headers['content-encoding'] === 'gzip' ||
-          res.headers['content-encoding'] === 'deflate') {
+      if (headers['content-encoding'] === 'gzip' ||
+          headers['content-encoding'] === 'deflate') {
         res = res.pipe(zlib.createUnzip());
       }
 
@@ -183,8 +188,8 @@ AlgoliaSearchNodeJS.prototype._request = function request(rawUrl, opts) {
         try {
           out = {
             body: JSON.parse(data),
-            statusCode: res.statusCode,
-            headers: res.headers
+            statusCode: statusCode,
+            headers: headers
           };
         } catch (e) {
           out = new errors.UnparsableJSON({

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,74 @@
+var debug = require('debug')('algoliasearch:src/hostIndexState.js');
+var localStorageNamespace = 'algoliasearch-client-js';
+
+var store;
+var moduleStore = {
+  state: {},
+  set: function(key, data) {
+    this.state[key] = data;
+    return this.state[key];
+  },
+  get: function(key) {
+    return this.state[key] || null;
+  }
+};
+
+var localStorageStore = {
+  set: function(key, data) {
+    try {
+      var namespace = JSON.parse(global.localStorage[localStorageNamespace]);
+      namespace[key] = data;
+      global.localStorage[localStorageNamespace] = JSON.stringify(namespace);
+      return namespace[key];
+    } catch (e) {
+      debug('localStorage set failed with', e);
+      cleanup();
+      store = moduleStore;
+      return store.set(key, data);
+    }
+  },
+  get: function(key) {
+    return JSON.parse(global.localStorage[localStorageNamespace])[key] || null;
+  }
+};
+
+store = supportsLocalStorage() ? localStorageStore : moduleStore;
+
+module.exports = {
+  get: getOrSet,
+  set: getOrSet
+};
+
+function getOrSet(key, data) {
+  if (arguments.length === 1) {
+    return store.get(key);
+  }
+
+  return store.set(key, data);
+}
+
+function supportsLocalStorage() {
+  try {
+    if ('localStorage' in global &&
+      global.localStorage !== null &&
+      !global.localStorage[localStorageNamespace]) {
+      // actual creation of the namespace
+      global.localStorage.setItem(localStorageNamespace, JSON.stringify({}));
+      return true;
+    }
+
+    return false;
+  } catch (_) {
+    return false;
+  }
+}
+
+// In case of any error on localStorage, we clean our own namespace, this should handle
+// quota errors when a lot of keys + data are used
+function cleanup() {
+  try {
+    global.localStorage.removeItem(localStorageNamespace);
+  } catch (_) {
+    // nothing to do
+  }
+}

--- a/test/run-browser.js
+++ b/test/run-browser.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.RESET_TO_FIRST_HOST_TIMER = 100;
+
 var domready = require('domready');
 
 // wait for domready to allo test runner to do ajax requests before we

--- a/test/run-node.js
+++ b/test/run-node.js
@@ -1,5 +1,7 @@
 'use strict';
 
+process.env.RESET_TO_FIRST_HOST_TIMER = 100;
+
 require('bulk-require')(__dirname, [
   'spec/common/**/*.js',
   'spec/node/**/*.js'

--- a/test/spec/common/request-strategy/active-hosts-state-shared-client-instantiations.js
+++ b/test/spec/common/request-strategy/active-hosts-state-shared-client-instantiations.js
@@ -1,0 +1,110 @@
+var test = require('tape');
+
+test('When not using custom hosts, active hosts state is shared amongst client instantiations', function(t) {
+  var fauxJax = require('faux-jax');
+  var parse = require('url-parse');
+  fauxJax.install({gzip: true});
+
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture();
+  var fixture2 = createFixture({
+    credentials: fixture.credentials
+  });
+  var fixture3 = createFixture({
+    credentials: fixture.credentials
+  });
+
+  var credentials = fixture.credentials;
+  var failingHost = credentials.applicationID.toLowerCase() + '-dsn.algolia.net';
+  var workingHost;
+  var firstClientIndex = fixture.index;
+  var secondClientIndex = fixture2.index;
+  var thirdClientIndex = fixture3.index;
+
+  var reqHandlers = [function(req) {
+    t.equal(
+      parse(req.requestURL).hostname,
+      failingHost,
+      'First client, first search, first request done on ' + failingHost
+    );
+
+    // simulate network error
+    req.respond(500, {}, JSON.stringify({}));
+  }, function(req) {
+    workingHost = parse(req.requestURL).hostname;
+    t.notEqual(
+      workingHost,
+      failingHost,
+      'First client, first search, second request not done on ' + failingHost
+    );
+    req.respond(200, {}, JSON.stringify({message: 'First client, first search, second request'}));
+  }, function(req) {
+    t.equal(
+      parse(req.requestURL).hostname,
+      workingHost,
+      'Second client, first search, first request done on ' + workingHost
+    );
+    req.respond(200, {}, JSON.stringify({message: 'Second client, first search, first request'}));
+  }, function(req) {
+    // after RESET_TO_FIRST_HOST_TIMER, we should try again the failing host
+    t.equal(
+      parse(req.requestURL).hostname,
+      failingHost,
+      'Third client, first search, first request done on ' + failingHost
+    );
+    req.respond(200, {}, JSON.stringify({message: 'Third client, first search, first request'}));
+  }];
+
+  var reqCount = 1;
+  fauxJax.on('request', function(req) {
+    if (reqCount > 4) {
+      t.fail('Received more requests than planned');
+    }
+    console.log(reqCount, 'count');
+    reqHandlers[reqCount - 1](req);
+    reqCount++;
+  });
+
+  firstSearch();
+
+  function firstSearch() {
+    firstClientIndex
+      .search('one', function(err, res) {
+        t.error(err, 'No error on first search');
+        t.deepEqual(res,
+          {
+            message: 'First client, first search, second request'
+          },
+          'First client, first search receives right message'
+        );
+        secondSearch();
+      });
+  }
+
+  function secondSearch() {
+    secondClientIndex.search('two', function(err, res) {
+      t.error(err, 'No error on second search');
+      t.deepEqual(res,
+        {
+          message: 'Second client, first search, first request'
+        },
+        'Second client, first search receives right message'
+      );
+      setTimeout(thirdSearch, parseInt(process.env.RESET_TO_FIRST_HOST_TIMER, 10));
+    });
+  }
+
+  function thirdSearch() {
+    thirdClientIndex.search('three', function(err, res) {
+      t.error(err, 'No error on third search');
+      t.deepEqual(res,
+        {
+          message: 'Third client, first search, first request'
+        },
+        'Third client, first search receives right message'
+      );
+      fauxJax.restore();
+      t.end();
+    });
+  }
+});

--- a/test/spec/common/request-strategy/try-active-hosts-first.js
+++ b/test/spec/common/request-strategy/try-active-hosts-first.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var test = require('tape');
+
+test('When using custom hosts, active hosts are tried first', function(t) {
+  t.plan(7);
+
+  var fauxJax = require('faux-jax');
+  var parse = require('url-parse');
+  fauxJax.install({gzip: true});
+
+  var createFixture = require('../../../utils/create-fixture');
+  var fixture = createFixture({
+    clientOptions: {
+      hosts: {
+        read: ['down-host.com', 'working-host.com'],
+        write: []
+      }
+    }
+  });
+
+  var index = fixture.index;
+
+  var reqHandlers = [function(req) {
+    t.equal(
+      parse(req.requestURL).hostname,
+      'down-host.com',
+      'First search, first request done on down-host.com'
+    );
+
+    // simulate network error
+    req.respond(500, {}, JSON.stringify({}));
+  }, function(req) {
+    // second request on working-host.com
+    t.equal(
+      parse(req.requestURL).hostname,
+      'working-host.com',
+      'First search, second request done on working-host.com'
+    );
+    req.respond(200, {}, JSON.stringify({message: 'First search, second request'}));
+  }, function(req) {
+    // third request on working-host.com
+    t.equal(
+      parse(req.requestURL).hostname,
+      'working-host.com',
+      'Second search, first request done on working-host.com'
+    );
+    req.respond(200, {}, JSON.stringify({message: 'Second search, first request'}));
+  }];
+
+  var reqCount = 1;
+  fauxJax.on('request', function(req) {
+    if (reqCount > 3) {
+      t.fail('Received more requests than planned');
+    }
+    reqHandlers[reqCount - 1](req);
+    reqCount++;
+  });
+
+  firstSearch();
+
+  function firstSearch() {
+    index
+      .search('one', function(err, res) {
+        t.error(err, 'No error on first search');
+        t.deepEqual(res, {message: 'First search, second request'}, 'First search receives right message');
+        secondSearch();
+      });
+  }
+
+  function secondSearch() {
+    index.search('two', function(err, res) {
+      t.error(err, 'No error on second search');
+      t.deepEqual(res, {message: 'Second search, first request'}, 'Second search receives right message');
+      fauxJax.restore();
+    });
+  }
+});

--- a/test/utils/create-fixture.js
+++ b/test/utils/create-fixture.js
@@ -8,7 +8,7 @@ function createFixture(opts) {
 
   opts = opts || {};
 
-  var credentials = getCredentials();
+  var credentials = opts.credentials || getCredentials();
 
   var client = algoliasearch(credentials.applicationID, credentials.searchOnlyAPIKey, opts.clientOptions);
   var index = client.initIndex(opts.indexName || credentials.indexName);


### PR DESCRIPTION
This commit adds another layer of HA by remembering the last known
work host for one minute.

The cache keys are either:
- domain + appId + browser => Browser localStorage
- process/pageLoad + appId => Node.js, Browser fallback

This is still a bit raw I think, have some review.